### PR TITLE
Fixing module ID bit attributed to z-side

### DIFF
--- a/DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h
@@ -94,7 +94,7 @@ public:
   static const int kHGCalLayerMask = 0x1F;
   static const int kHGCalTypeOffset = 19;
   static const int kHGCalTypeMask = 0x3;
-  static const int kHGCalZsideOffset = 24;
+  static const int kHGCalZsideOffset = 21;
   static const int kHGCalZsideMask = 0x1;
   static const int kHGCalTriggerSubdetOffset = 22;
   static const int kHGCalTriggerSubdetMask = 0x3;


### PR DESCRIPTION
#### PR description:

The module ID includes the z-side information on bit 24 instead of bit 21 as it should (from the header description). This creates a conflict with the classID bit (actual 24th bit). The PR simply reassigns it to the correct bit.