### PR TITLE
Analyzer for extraction of trigger geometry and backend S1 parameters into a JSON file

### DIFF
--- a/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl_SA.h
+++ b/L1Trigger/L1THGCal/interface/backend/HGCalStage1TruncationImpl_SA.h
@@ -20,6 +20,10 @@ public:
                const l1thgcfirmware::Stage1TruncationConfig& theConf,
                l1thgcfirmware::HGCalTriggerCellSACollection& tcs_out) const;
 
+  int phiBin(unsigned roverzbin, double phi, const std::vector<double>& phiedges) const;
+  double rotatedphi(double x, double y, double z, int sector) const;
+  unsigned rozBin(double roverz, double rozmin, double rozmax, unsigned rozbins) const;
+
 private:
   static constexpr unsigned offset_roz_ = 1;
   static constexpr unsigned mask_roz_ = 0x3f;  // 6 bits, max 64 bins
@@ -34,8 +38,6 @@ private:
 
   uint32_t packBin(unsigned roverzbin, unsigned phibin) const;
   void unpackBin(unsigned packedbin, unsigned& roverzbin, unsigned& phibin) const;
-  int phiBin(unsigned roverzbin, double phi, const std::vector<double>& phiedges) const;
-  double rotatedphi(double x, double y, double z, int sector) const;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl_SA.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalStage1TruncationImpl_SA.cc
@@ -17,19 +17,14 @@ unsigned HGCalStage1TruncationImplSA::run(const l1thgcfirmware::HGCalTriggerCell
   const std::vector<unsigned>& maxtcsperbin = theConf.maxTcsPerBin();
   const std::vector<double>& phiedges = theConf.phiEdges();
 
-  constexpr double margin = 1.001;
-  double roz_bin_size = (rozbins > 0 ? (rozmax - rozmin) * margin / double(rozbins) : 0.);
-
   // group TCs per (r/z, phi) bins
   for (const auto& tc : tcs_in) {
     double x = tc.x();
     double y = tc.y();
     double z = tc.z();
     double roverz = std::sqrt(x * x + y * y) / std::abs(z);
-    roverz = (roverz < rozmin ? rozmin : roverz);
-    roverz = (roverz > rozmax ? rozmax : roverz);
+    unsigned roverzbin = rozBin(roverz, rozmin, rozmax, rozbins);
 
-    unsigned roverzbin = (roz_bin_size > 0. ? unsigned((roverz - rozmin) / roz_bin_size) : 0);
     double phi = rotatedphi(x, y, z, sector120);
     int phibin = phiBin(roverzbin, phi, phiedges);
     if (phibin < 0)
@@ -101,4 +96,15 @@ double HGCalStage1TruncationImplSA::rotatedphi(double x, double y, double z, int
     phi = phi + (2. * M_PI / 3.);
   }
   return phi;
+}
+
+unsigned HGCalStage1TruncationImplSA::rozBin(double roverz, double rozmin, double rozmax, unsigned rozbins) const {
+  constexpr double margin = 1.001;
+  double roz_bin_size = (rozbins > 0 ? (rozmax - rozmin) * margin / double(rozbins) : 0.);
+
+  roverz = (roverz < rozmin ? rozmin : roverz);
+  roverz = (roverz > rozmax ? rozmax : roverz);
+  unsigned roverzbin = (roz_bin_size > 0. ? unsigned((roverz - rozmin) / roz_bin_size) : 0);
+
+  return roverzbin;
 }

--- a/L1Trigger/L1THGCal/test/BuildFile.xml
+++ b/L1Trigger/L1THGCal/test/BuildFile.xml
@@ -2,6 +2,6 @@
 <use name="L1Trigger/L1THGCal"/>
 <use name="Geometry/Records"/>
 <use name="CommonTools/UtilAlgos"/>
-<library name="testL1TriggerL1THGCal" file="HGCalTriggerGeomTesterV9Imp2.cc,HGCalTriggerGeomTesterV9Imp3.cc">
+<library name="testL1TriggerL1THGCal" file="HGCalTriggerGeomTesterV9Imp2.cc,HGCalTriggerGeomTesterV9Imp3.cc,HGCalBackendStage1ParameterExtractor.cc">
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
+++ b/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
@@ -42,9 +42,7 @@ private:
 
   // Metadata
   std::string detector_version_;
-  std::string cmssw_era_;
-
-  uint32_t the_fpga_;
+  int the_fpga_;
 
   // geometry data
   std::vector<uint32_t> disconnected_layers_;
@@ -76,12 +74,11 @@ HGCalBackendStage1ParameterExtractor::HGCalBackendStage1ParameterExtractor(const
   outJSONname_ = conf.getParameter<std::string>("outJSONname");
 
   // get ID of tested FPGA
-  the_fpga_ = conf.getParameter<uint32_t>("testedFpga");
+  the_fpga_ = conf.getParameter<int>("testedFpga");
 
   // get meta data
   const edm::ParameterSet& metaData = conf.getParameterSet("MetaData");
-  cmssw_era_ = "dummy1";//metaData.getParameter<std::string>("CMSSW_era");
-  detector_version_ = "dummy2";//metaData.getParameter<std::string>("detector_version_");
+  detector_version_ = metaData.getParameter<std::string>("geometryVersion");
 
   // get geometry configuration
   const edm::ParameterSet& triggerGeom = conf.getParameterSet("TriggerGeometryParam");
@@ -116,8 +113,7 @@ void HGCalBackendStage1ParameterExtractor::beginRun(const edm::Run& /*run*/, con
   json outJSON;
 
   // fill MetaData
-  outJSON["MetaData"]["CMSSWEra"] = cmssw_era_;
-  outJSON["MetaData"]["DetectorVersion"] = detector_version_;
+  outJSON["MetaData"]["GeometryVersion"] = detector_version_;
   outJSON["MetaData"]["fpgaId"] = the_fpga_;
 
   // fill geometry configuration
@@ -176,7 +172,7 @@ void HGCalBackendStage1ParameterExtractor::fillTriggerGeometry(json& json_file) 
     HGCalTriggerBackendDetId tc_fpga(fpgaId);
     if (!(tc_fpga.isStage1FPGA()) || (tc_fpga.sector() != 0) || (tc_fpga.zside() < 0))
       continue;
-    if ((uint32_t)tc_fpga.label() != the_fpga_)
+    if (tc_fpga.label() != the_fpga_)
       continue;
 
     // retrieve information to be saved

--- a/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
+++ b/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
@@ -1,6 +1,5 @@
 #include <iostream> // std::cout
 #include <fstream>  // std::ofstream
-#include <any> // std::any
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/stream/EDAnalyzer.h"
@@ -252,8 +251,6 @@ void HGCalBackendStage1ParameterExtractor::fillTriggerGeometry(json& json_file) 
     json j1;
     j1["hash"] = module_json.key();
     j1["tcs"] = module_json.value();
-     
-
     json_file["TriggerCellMap"]["Module"].push_back(j1);
   }
 }

--- a/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
+++ b/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
@@ -31,8 +31,6 @@ public:
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
 private:
-  bool checkMappingConsistency();
-
   void fillTriggerGeometry(json& json_file);
 
   edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
@@ -65,9 +63,6 @@ private:
 
   // output json name:
   std::string outJSONname_;
-
-  // mapping consistency check result
-  bool no_trigger_ = false;
 
   typedef std::unordered_map<uint32_t, std::unordered_set<uint32_t>> trigger_map_set;
 };
@@ -122,9 +117,6 @@ HGCalBackendStage1ParameterExtractor::~HGCalBackendStage1ParameterExtractor() {}
 void HGCalBackendStage1ParameterExtractor::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es) {
   triggerGeometry_ = es.getHandle(triggerGeomToken_);
 
-  // note: identical function in geometry tester; should it be imported instead?
-  no_trigger_ = !checkMappingConsistency();
-
   json outJSON;
 
   // fill MetaData
@@ -157,398 +149,47 @@ void HGCalBackendStage1ParameterExtractor::beginRun(const edm::Run& /*run*/, con
   outputfile << std::setw(4) << outJSON << std::endl;
 }
 
-bool HGCalBackendStage1ParameterExtractor::checkMappingConsistency() {
-  try {
-    // Set of (subdet,layer,waferU,waferV) with module mapping errors
-    std::set<std::tuple<uint32_t, uint32_t, int, int>> module_errors;
-    trigger_map_set modules_to_triggercells;
-    trigger_map_set modules_to_cells;
-    trigger_map_set triggercells_to_cells;
-    // EE
-    for (const auto& id : triggerGeometry_->eeGeometry()->getValidDetIds()) {
-      HGCSiliconDetId detid(id);
-      if (!triggerGeometry_->eeTopology().valid(id))
-        continue;
-      // fill trigger cells
-      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
-      auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
-      itr_insert.first->second.emplace(id);
-      // fill modules
-      uint32_t module = 0;
-      try {
-        module = triggerGeometry_->getModuleFromCell(id);
-        triggerGeometry_->getLinksInModule(module);
-      } catch (const std::exception& e) {
-        module_errors.emplace(std::make_tuple(HGCalTriggerModuleDetId(module).triggerSubdetId(),
-                                              HGCalTriggerModuleDetId(module).layer(),
-                                              HGCalTriggerModuleDetId(module).moduleU(),
-                                              HGCalTriggerModuleDetId(module).moduleV()));
-        continue;
-      }
-      itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
-      itr_insert.first->second.emplace(id);
-    }
-
-    // HSi
-    for (const auto& id : triggerGeometry_->hsiGeometry()->getValidDetIds()) {
-      if (!triggerGeometry_->hsiTopology().valid(id))
-        continue;
-      // fill trigger cells
-      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
-      auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
-      itr_insert.first->second.emplace(id);
-      // fill modules
-      uint32_t module = 0;
-      try {
-        module = triggerGeometry_->getModuleFromCell(id);
-        triggerGeometry_->getLinksInModule(module);
-      } catch (const std::exception& e) {
-        module_errors.emplace(std::make_tuple(HGCalTriggerModuleDetId(module).triggerSubdetId(),
-                                              HGCalTriggerModuleDetId(module).layer(),
-                                              HGCalTriggerModuleDetId(module).moduleU(),
-                                              HGCalTriggerModuleDetId(module).moduleV()));
-        continue;
-      }
-      itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
-      itr_insert.first->second.emplace(id);
-    }
-
-    // HSc
-    for (const auto& id : triggerGeometry_->hscGeometry()->getValidDetIds()) {
-      // fill trigger cells
-      uint32_t layer = HGCScintillatorDetId(id).layer();
-      if (HGCScintillatorDetId(id).type() != triggerGeometry_->hscTopology().dddConstants().getTypeTrap(layer)) {
-        std::cout << "Sci cell type = " << HGCScintillatorDetId(id).type()
-                  << " != " << triggerGeometry_->hscTopology().dddConstants().getTypeTrap(layer) << "\n";
-      }
-      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
-      auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
-      itr_insert.first->second.emplace(id);
-      // fill modules
-      uint32_t module = triggerGeometry_->getModuleFromCell(id);
-      if (module != 0) {
-        itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
-        itr_insert.first->second.emplace(id);
-      }
-    }
-
-    // NOSE
-    if (triggerGeometry_->isWithNoseGeometry()) {
-      for (const auto& id : triggerGeometry_->noseGeometry()->getValidDetIds()) {
-        if (!triggerGeometry_->noseTopology().valid(id))
-          continue;
-        // fill trigger cells
-        uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
-        auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
-        itr_insert.first->second.emplace(id);
-        // fill modules
-        uint32_t module = triggerGeometry_->getModuleFromCell(id);
-        if (module != 0) {
-          itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
-          itr_insert.first->second.emplace(id);
-        }
-      }
-    }
-
-    if (module_errors.size() > 0) {
-      throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: Found  module mapping problems. Check the produced "
-                                             "tree to see the list of problematic wafers";
-    }
-
-    edm::LogPrint("TriggerCellCheck") << "Checking cell -> trigger cell -> cell consistency";
-    // Loop over trigger cells
-    for (const auto& triggercell_cells : triggercells_to_cells) {
-      DetId id(triggercell_cells.first);
-
-      // fill modules
-      uint32_t module = triggerGeometry_->getModuleFromTriggerCell(id);
-      if (module != 0) {
-        auto itr_insert = modules_to_triggercells.emplace(module, std::unordered_set<uint32_t>());
-        itr_insert.first->second.emplace(id);
-      }
-
-      // Check consistency of cells included in trigger cell
-      HGCalTriggerGeometryBase::geom_set cells_geom = triggerGeometry_->getCellsFromTriggerCell(id);
-      const auto& cells = triggercell_cells.second;
-      for (auto cell : cells) {
-        if (cells_geom.find(cell) == cells_geom.end()) {
-          if (id.det() == DetId::HGCalHSc) {
-            edm::LogProblem("BadTriggerCell")
-                << "Error: \n Cell " << cell << "(" << HGCScintillatorDetId(cell)
-                << ")\n has not been found in \n trigger cell " << HGCScintillatorDetId(id);
-            std::stringstream output;
-            output << " Available cells are:\n";
-            for (auto cell_geom : cells_geom)
-              output << "     " << HGCScintillatorDetId(cell_geom) << "\n";
-            edm::LogProblem("BadTriggerCell") << output.str();
-          } else if (HFNoseTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
-            edm::LogProblem("BadTriggerCell")
-                << "Error: \n Cell " << cell << "(" << HFNoseDetId(cell) << ")\n has not been found in \n trigger cell "
-                << HFNoseTriggerDetId(triggercell_cells.first);
-            std::stringstream output;
-            output << " Available cells are:\n";
-            for (auto cell_geom : cells_geom)
-              output << "     " << HFNoseDetId(cell_geom) << "\n";
-            edm::LogProblem("BadTriggerCell") << output.str();
-          } else if (HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalEETrigger ||
-                     HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalHSiTrigger) {
-            edm::LogProblem("BadTriggerCell")
-                << "Error: \n Cell " << cell << "(" << HGCSiliconDetId(cell)
-                << ")\n has not been found in \n trigger cell " << HGCalTriggerDetId(triggercell_cells.first);
-            std::stringstream output;
-            output << " Available cells are:\n";
-            for (auto cell_geom : cells_geom)
-              output << "     " << HGCSiliconDetId(cell_geom) << "\n";
-            edm::LogProblem("BadTriggerCell") << output.str();
-          } else {
-            edm::LogProblem("BadTriggerCell")
-                << "Unknown detector type " << id.det() << " " << id.subdetId() << " " << id.rawId() << "\n";
-            edm::LogProblem("BadTriggerCell") << " cell " << std::hex << cell << std::dec << " "
-                                              << "\n";
-            edm::LogProblem("BadTriggerCell")
-                << "Cell ID " << HGCSiliconDetId(cell) << " or " << HFNoseDetId(cell) << "\n";
-          }
-          throw cms::Exception("BadGeometry")
-              << "HGCalTriggerGeometry: Found inconsistency in cell <-> trigger cell mapping";
-        }
-      }
-    }
-    edm::LogPrint("ModuleCheck") << "Checking trigger cell -> module -> trigger cell consistency";
-    // Loop over modules
-    for (const auto& module_triggercells : modules_to_triggercells) {
-      HGCalTriggerModuleDetId id(module_triggercells.first);
-      // Check consistency of trigger cells included in module
-      HGCalTriggerGeometryBase::geom_set triggercells_geom = triggerGeometry_->getTriggerCellsFromModule(id);
-      const auto& triggercells = module_triggercells.second;
-      for (auto cell : triggercells) {
-        if (triggercells_geom.find(cell) == triggercells_geom.end()) {
-          if (id.triggerSubdetId() == HGCalTriggerSubdetector::HGCalHScTrigger) {
-            HGCScintillatorDetId cellid(cell);
-            edm::LogProblem("BadModule") << "Error: \n Trigger cell " << cell << "(" << cellid
-                                         << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
-            std::stringstream output;
-            output << " Available trigger cells are:\n";
-            for (auto cell_geom : triggercells_geom) {
-              output << "     " << HGCScintillatorDetId(cell_geom) << "\n";
-            }
-            edm::LogProblem("BadModule") << output.str();
-            throw cms::Exception("BadGeometry")
-                << "HGCalTriggerGeometry: Found inconsistency in trigger cell <->  module mapping";
-          } else if (id.triggerSubdetId() == HGCalTriggerSubdetector::HFNoseTrigger) {
-            HFNoseTriggerDetId cellid(cell);
-            edm::LogProblem("BadModule") << "Error : \n Trigger cell " << cell << "(" << cellid
-                                         << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
-            std::stringstream output;
-            output << " Available trigger cells are:\n";
-            for (auto cell_geom : triggercells_geom) {
-              output << "     " << HFNoseTriggerDetId(cell_geom) << "\n";
-            }
-            edm::LogProblem("BadModule") << output.str();
-            throw cms::Exception("BadGeometry")
-                << "HGCalTriggerGeometry: Found inconsistency in trigger cell <->  module mapping";
-          } else {
-            HGCalTriggerDetId cellid(cell);
-            edm::LogProblem("BadModule") << "Error : \n Trigger cell " << cell << "(" << cellid
-                                         << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
-            std::stringstream output;
-            output << " Available trigger cells are:\n";
-            for (auto cell_geom : triggercells_geom) {
-              output << "     " << HGCalTriggerDetId(cell_geom) << "\n";
-            }
-            edm::LogProblem("BadModule") << output.str();
-            throw cms::Exception("BadGeometry")
-                << "HGCalTriggerGeometry: Found inconsistency in trigger cell <->  module mapping";
-          }
-        }
-      }
-    }
-    edm::LogPrint("ModuleCheck") << "Checking cell -> module -> cell consistency";
-    for (const auto& module_cells : modules_to_cells) {
-      HGCalTriggerModuleDetId id(module_cells.first);
-      // Check consistency of cells included in module
-      HGCalTriggerGeometryBase::geom_set cells_geom = triggerGeometry_->getCellsFromModule(id);
-      const auto& cells = module_cells.second;
-      for (auto cell : cells) {
-        if (cells_geom.find(cell) == cells_geom.end()) {
-          if (id.triggerSubdetId() == HGCalTriggerSubdetector::HGCalHScTrigger) {
-            edm::LogProblem("BadModule") << "Error: \n Cell " << cell << "(" << HGCScintillatorDetId(cell)
-                                         << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
-          } else if (id.triggerSubdetId() == HGCalTriggerSubdetector::HFNoseTrigger) {
-            edm::LogProblem("BadModule") << "Error: \n Cell " << cell << "(" << HFNoseDetId(cell)
-                                         << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
-          } else {
-            edm::LogProblem("BadModule") << "Error: \n Cell " << cell << "(" << HGCSiliconDetId(cell)
-                                         << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
-          }
-          std::stringstream output;
-          output << " Available cells are:\n";
-          for (auto cell_geom : cells_geom) {
-            output << cell_geom << " ";
-          }
-          edm::LogProblem("BadModule") << output.str();
-          throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: Found inconsistency in cell <-> module mapping";
-        }
-      }
-    }
-
-    // Filling Stage 1 FPGA -> modules
-
-    edm::LogPrint("ModuleCheck") << "Checking module -> stage-1 -> module consistency";
-    trigger_map_set stage1_to_modules;
-    for (const auto& module_tc : modules_to_triggercells) {
-      HGCalTriggerModuleDetId id(module_tc.first);
-      HGCalTriggerGeometryBase::geom_set lpgbts = triggerGeometry_->getLpgbtsFromModule(id);
-      if (lpgbts.size() == 0)
-        continue;  //Module is not connected to an lpGBT and therefore not to a Stage 1 FPGA
-      uint32_t stage1 = 0;
-      for (const auto& lpgbt : lpgbts) {
-        uint32_t stage1_tmp = triggerGeometry_->getStage1FpgaFromLpgbt(lpgbt);
-        if (stage1 != 0 && stage1_tmp != stage1) {
-          throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: Module " << HGCalTriggerModuleDetId(id)
-                                              << " is split is split into more than one Stage-1 FPGA";
-        }
-        stage1 = stage1_tmp;
-      }
-      auto itr_insert = stage1_to_modules.emplace(stage1, std::unordered_set<uint32_t>());
-      itr_insert.first->second.emplace(id);
-    }
-    // checking S1 -> module consistency
-
-    for (const auto& stage1_modules : stage1_to_modules) {
-      HGCalTriggerBackendDetId stage1(stage1_modules.first);
-      HGCalTriggerGeometryBase::geom_set modules_geom;
-      // Check consistency of modules going to Stage-1 FPGA
-      HGCalTriggerGeometryBase::geom_set lpgbts = triggerGeometry_->getLpgbtsFromStage1Fpga(stage1);
-      for (const auto& lpgbt : lpgbts) {
-        HGCalTriggerGeometryBase::geom_set modules = triggerGeometry_->getModulesFromLpgbt(lpgbt);
-        modules_geom.insert(modules.begin(), modules.end());
-      }
-      const auto& modules = stage1_modules.second;
-      for (auto module : modules) {
-        if (modules_geom.find(module) == modules_geom.end()) {
-          edm::LogProblem("BadStage1") << "Error: \n Module " << module << "(" << HGCalTriggerModuleDetId(module)
-                                       << ")\n has not been found in \n stage-1 " << HGCalTriggerBackendDetId(stage1);
-          std::stringstream output;
-          output << "   Available modules are:\n";
-          for (auto module_geom : modules_geom) {
-            output << module_geom << " ";
-          }
-          output << "   Connected lpgbts are:\n";
-          for (auto lpgbt : lpgbts) {
-            output << lpgbt << " ";
-          }
-          edm::LogProblem("BadStage1") << output.str();
-          throw cms::Exception("BadGeometry")
-              << "HGCalTriggerGeometry: Found inconsistency in Stage1 <-> module mapping";
-        }
-      }
-    }
-
-    // Filling Stage 2 FPGA -> Stage 1 FPGA
-
-    edm::LogPrint("ModuleCheck") << "Checking Stage 1 -> Stage 2 -> Stage 1 consistency";
-    trigger_map_set stage2_to_stage1;
-    for (const auto& stage1 : stage1_to_modules) {
-      HGCalTriggerBackendDetId id(stage1.first);
-      HGCalTriggerGeometryBase::geom_set stage2FPGAs = triggerGeometry_->getStage2FpgasFromStage1Fpga(id);
-      for (const auto& stage2 : stage2FPGAs) {
-        auto itr_insert = stage2_to_stage1.emplace(stage2, std::unordered_set<uint32_t>());
-        itr_insert.first->second.emplace(id);
-      }
-    }
-    // checking S1 -> S2 consistency
-
-    for (const auto& stage2_modules : stage2_to_stage1) {
-      HGCalTriggerBackendDetId stage2(stage2_modules.first);
-
-      // Check consistency of Stage-1 FPGA going to Stage 2 FPGA
-      HGCalTriggerGeometryBase::geom_set stage1FPGAs = triggerGeometry_->getStage1FpgasFromStage2Fpga(stage2);
-
-      const auto& stage1fpgas = stage2_modules.second;
-
-      for (auto stage1fpga : stage1fpgas) {
-        if (stage1FPGAs.find(stage1fpga) == stage1FPGAs.end()) {
-          edm::LogProblem("BadStage2") << "Error: \n Stage-1 FPGA " << stage1fpga << "("
-                                       << HGCalTriggerBackendDetId(stage1fpga)
-                                       << ")\n has not been found in \n Stage-2 " << HGCalTriggerBackendDetId(stage2);
-          std::stringstream output;
-          output << "\n   Available Stage-1 FPGAs are:\n";
-          for (auto stage1FPGA : stage1FPGAs) {
-            output << HGCalTriggerBackendDetId(stage1FPGA) << "\n";
-          }
-          edm::LogProblem("BadStage2") << output.str();
-          throw cms::Exception("BadGeometry")
-              << "HGCalTriggerGeometry: Found inconsistency in Stage2 <-> Stage1 mapping";
-        }
-      }
-    }
-
-  } catch (const cms::Exception& e) {
-    edm::LogWarning("HGCalTriggerGeometryTester")
-        << "Problem with the trigger geometry detected. Only the basic cells tree will be filled\n";
-    edm::LogWarning("HGCalTriggerGeometryTester") << e.message() << "\n";
-    return false;
-  }
-  return true;
-}
-
 void HGCalBackendStage1ParameterExtractor::fillTriggerGeometry(json& json_file) {
   trigger_map_set trigger_cells;
 
-  // check geometry and retrieve trigger cells
-  std::cout << "Checking EE geometry\n";
+  // retrieve valid trigger cells
+  std::cout << "Getting EE trigger cells\n";
   for (const auto& id : triggerGeometry_->eeGeometry()->getValidDetIds()) {
     HGCSiliconDetId detid(id);
     if (!triggerGeometry_->eeTopology().valid(id))
       continue;
-    // fill trigger cells
-    if (!no_trigger_) {
-      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
-      auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
-      itr_insert.first->second.emplace(id);
-    }
+    uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+    auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+    itr_insert.first->second.emplace(id);
   }
-  std::cout << "Checking HSi geometry\n";
+  std::cout << "Getting HSi trigger cells\n";
   for (const auto& id : triggerGeometry_->hsiGeometry()->getValidDetIds()) {
     HGCSiliconDetId detid(id);
     if (!triggerGeometry_->hsiTopology().valid(id))
       continue;
-    // fill trigger cells
-    if (!no_trigger_) {
-      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
-      auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
-      itr_insert.first->second.emplace(id);
-    }
+    uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+    auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+    itr_insert.first->second.emplace(id);
   }
-  std::cout << "Checking HSc geometry\n";
+  std::cout << "Getting HSc trigger cells\n";
   for (const auto& id : triggerGeometry_->hscGeometry()->getValidDetIds()) {
-    if (!no_trigger_) {
-      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
-      auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
-      itr_insert.first->second.emplace(id);
-    }
+    uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+    auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+    itr_insert.first->second.emplace(id);
   }
   if (triggerGeometry_->isWithNoseGeometry()) {
-    std::cout << "Checking NOSE geometry\n";
+    std::cout << "Getting NOSE trigger cells\n";
     for (const auto& id : triggerGeometry_->noseGeometry()->getValidDetIds()) {
-      // fill trigger cells
-      if (!no_trigger_) {
-        uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
-        auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
-        itr_insert.first->second.emplace(id);
-      }
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
     }
   }
-
-  // if problem detected in the trigger geometry, don't produce the TC map
-  if (no_trigger_)
-    return;
 
   // loop over trigger cells
   edm::LogPrint("JSONFilling") << "Filling JSON map";
   for (const auto& triggercell_cells : trigger_cells) {
     DetId id(triggercell_cells.first);
-
     // get module ID and check if relevant module (sector0, zside=-1)
     uint32_t moduleId = triggerGeometry_->getModuleFromTriggerCell(id);
     if (moduleId == 0)
@@ -604,7 +245,7 @@ void HGCalBackendStage1ParameterExtractor::fillTriggerGeometry(json& json_file) 
     float triggerCellPhi = position.phi();
     float triggerCellRoverZ = sqrt(triggerCellX * triggerCellX + triggerCellY * triggerCellY) / triggerCellZ;
 
-    // transform HGCalHSc TC coordinates to define a TC id in [0,47]
+    // transform HGCalHSc TC coordinates to define a TC address in [0,47]
     uint32_t tce = triggerCellUEta;
     uint32_t tcp = triggerCellVPhi;
     if (triggerCellSubdet == 10) {  // HGCalHSc

--- a/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
+++ b/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
@@ -61,7 +61,6 @@ private:
   double roz_min_;
   double roz_max_;
   uint32_t roz_bins_;
-  double roz_bin_size_;
   std::vector<uint32_t> max_tcs_per_bins_;
   std::vector<double> phi_edges_;
 
@@ -110,9 +109,6 @@ HGCalBackendStage1ParameterExtractor::HGCalBackendStage1ParameterExtractor(const
   roz_max_ = truncationParamConfig.getParameter<double>("rozMax");
   roz_bins_ = truncationParamConfig.getParameter<uint32_t>("rozBins");
 
-  constexpr double margin = 1.001;
-  roz_bin_size_ = (roz_bins_ > 0 ? (roz_max_ - roz_min_) * margin / double(roz_bins_) : 0.);
-
   max_tcs_per_bins_ = truncationParamConfig.getParameter<std::vector<uint32_t>>("maxTcsPerBin");
   phi_edges_ = truncationParamConfig.getParameter<std::vector<double>>("phiSectorEdges");
 }
@@ -138,7 +134,6 @@ void HGCalBackendStage1ParameterExtractor::beginRun(const edm::Run& /*run*/, con
   outJSON["TruncationConfig"]["rozMin"] = roz_min_;
   outJSON["TruncationConfig"]["rozMax"] = roz_max_;
   outJSON["TruncationConfig"]["rozBins"] = roz_bins_;
-  outJSON["TruncationConfig"]["rozBinSize"] = roz_bin_size_;
   outJSON["TruncationConfig"]["maxTcsPerBin"] = max_tcs_per_bins_;
   outJSON["TruncationConfig"]["phiSectorEdges"] = phi_edges_;
 

--- a/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
+++ b/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
@@ -1,33 +1,23 @@
-#include <iostream>
+#include <iostream> // std::cout
 #include <fstream>  // std::ofstream
-#include <vector>
-#include <cstdlib>
-#include <any>
 
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ESTransientHandle.h"
-#include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
-#include "DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
-#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
-
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
-
-#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCalTriggerBackendDetId.h"
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
 
 #include <nlohmann/json.hpp>
 using json = nlohmann::ordered_json;  // using ordered_json for readability
@@ -42,8 +32,7 @@ public:
 
 private:
   bool checkMappingConsistency();
-  void fillMetaData(json& json_file);
-  void fillMethodConfig(json& json_file);
+
   void fillTriggerGeometry(json& json_file);
 
   edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;

--- a/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
+++ b/L1Trigger/L1THGCal/test/HGCalBackendStage1ParameterExtractor.cc
@@ -1,0 +1,674 @@
+#include <iostream>
+#include <fstream>   // std::ofstream
+#include <vector>
+#include <cstdlib>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
+#include "DataFormats/ForwardDetId/interface/HFNoseTriggerDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerBackendDetId.h"
+
+#include <nlohmann/json.hpp>
+using json = nlohmann::ordered_json; // using ordered_json for readability
+
+class HGCalBackendStage1ParameterExtractor : public edm::stream::EDAnalyzer<> {
+public:
+  explicit HGCalBackendStage1ParameterExtractor(const edm::ParameterSet&);
+  ~HGCalBackendStage1ParameterExtractor();
+
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+private:
+  bool checkMappingConsistency(); // this I'm not sure what it does
+  void fillMetaData(json& json_file);
+  void fillMethodConfig(json& json_file);
+  void fillTriggerGeometry(json& json_file);
+
+  edm::ESHandle<HGCalTriggerGeometryBase> triggerGeometry_;
+  edm::ESGetToken<HGCalTriggerGeometryBase, CaloGeometryRecord> triggerGeomToken_;
+
+  // Metadata
+  std::string cmssw_version_;  
+  int the_fpga_;
+
+  // geometry data
+  std::vector<unsigned> disconnected_layers_;
+  std::vector<unsigned> disconnected_modules_;
+  std::string json_mapping_file_;
+  std::string L1T_links_mapping_;
+  std::string L1T_modules_mapping_;
+  unsigned scintillator_links_per_module_;
+  unsigned scintillator_module_size_;
+  unsigned scintillator_trigger_cell_size_;
+  std::string trigger_geom_;
+
+  // truncation parameters
+  double roz_min_;
+  double roz_max_;
+  unsigned roz_bins_;
+  std::vector<unsigned> max_tcs_per_bins_;
+  std::vector<double> phi_edges_;
+
+  // TC map parameters:
+  std::map<std::pair<unsigned,unsigned>, unsigned> tc_coord_uv_;
+
+  // output json name:
+  std::string outJSONname_;
+
+  // mapping consistency check result
+  bool no_trigger_ =false;
+
+  typedef std::unordered_map< uint32_t, std::unordered_set< uint32_t > > trigger_map_set;
+};
+
+HGCalBackendStage1ParameterExtractor::HGCalBackendStage1ParameterExtractor(const edm::ParameterSet& conf)
+  : triggerGeomToken_(esConsumes<HGCalTriggerGeometryBase, CaloGeometryRecord, edm::Transition::BeginRun>())
+
+{  
+  // Get name of output JSON config file
+  outJSONname_ = conf.getParameter<std::string>("outJSONname");
+
+  the_fpga_ = conf.getParameter<int>("testedFpga");
+
+  // Get meta data
+  const edm::ParameterSet& metaData = conf.getParameterSet("MetaData");
+  cmssw_version_ = metaData.getParameter<std::string>("CMSSW_version");
+
+  // Get geometry configuration
+  const edm::ParameterSet& triggerGeom = conf.getParameterSet("TriggerGeometryParam");
+  disconnected_layers_ = triggerGeom.getParameter<std::vector<unsigned>>("DisconnectedLayers");
+  disconnected_modules_ = triggerGeom.getParameter<std::vector<unsigned>>("DisconnectedModules");
+  json_mapping_file_ = triggerGeom.getParameter<edm::FileInPath>("JsonMappingFile").relativePath();
+  L1T_links_mapping_ = triggerGeom.getParameter<edm::FileInPath>("L1TLinksMapping").relativePath();
+  L1T_modules_mapping_ = triggerGeom.getParameter<edm::FileInPath>("L1TModulesMapping").relativePath();
+  scintillator_links_per_module_ = triggerGeom.getParameter<unsigned>("ScintillatorLinksPerModule");
+  scintillator_module_size_ = triggerGeom.getParameter<unsigned>("ScintillatorModuleSize");
+  scintillator_trigger_cell_size_ = triggerGeom.getParameter<unsigned>("ScintillatorTriggerCellSize");
+  trigger_geom_ = triggerGeom.getParameter<std::string>("TriggerGeometryName");
+  
+
+
+  const edm::ParameterSet& TCcoord_uv = conf.getParameterSet("TCcoord_UV");
+  std::vector<unsigned> tc_coord_u = TCcoord_uv.getParameter<std::vector<unsigned>>("TCu");
+  std::vector<unsigned> tc_coord_v = TCcoord_uv.getParameter<std::vector<unsigned>>("TCv");
+  
+  if(tc_coord_u.size() != tc_coord_v.size())
+    throw cms::Exception("BadParameter") << "TCu and TCv vectors should be of same size";
+  
+ 
+  for (size_t i=0; i<tc_coord_u.size(); ++i) 
+    tc_coord_uv_.emplace(std::make_pair(tc_coord_u.at(i),tc_coord_v.at(i)), i);
+
+  // Get truncation parameters
+  const edm::ParameterSet& truncationParamConfig = conf.getParameterSet("BackendStage1Params").getParameterSet("truncation_parameters");
+  roz_min_ = truncationParamConfig.getParameter<double>("rozMin");
+  roz_max_ = truncationParamConfig.getParameter<double>("rozMax");
+  roz_bins_ = truncationParamConfig.getParameter<unsigned>("rozBins");
+  max_tcs_per_bins_ = truncationParamConfig.getParameter<std::vector<unsigned>>("maxTcsPerBin");
+  phi_edges_ = truncationParamConfig.getParameter<std::vector<double>>("phiSectorEdges");
+
+
+}
+
+HGCalBackendStage1ParameterExtractor::~HGCalBackendStage1ParameterExtractor() {}
+
+void HGCalBackendStage1ParameterExtractor::beginRun(const edm::Run& /*run*/, const edm::EventSetup& es)
+{
+  // can't this be done in initialization?
+  triggerGeometry_ = es.getHandle(triggerGeomToken_);
+
+  // check what that does
+  no_trigger_ = !checkMappingConsistency();
+  
+  json outJSON;
+  fillMetaData(outJSON);
+  fillMethodConfig(outJSON);
+
+  std::cout << "CMSSW version = "<< outJSON["MetaData"]["CMSSWversion"] << std::endl;
+  std::cout << "Geometry version = "<< outJSON["TriggerGeometry"]["TriggerGeometryName"] << std::endl;
+  std::cout << "rozmin = " << outJSON["TruncationConfig"]["rozMin"] << std::endl;
+
+  fillTriggerGeometry(outJSON);
+
+  std::ofstream outputfile(outJSONname_.c_str());
+  outputfile << std::setw(4) << outJSON << std::endl;
+
+
+}
+/*****************************/
+/* are these really useful ? */
+/*****************************/
+void HGCalBackendStage1ParameterExtractor::fillMetaData(json& json_file) {
+
+  json_file["MetaData"]["CMSSWversion"] = cmssw_version_;
+  json_file["MetaData"]["fpgaId"] = the_fpga_;
+
+  json_file["TriggerGeometry"]["TriggerGeometryName"] = trigger_geom_;
+  json_file["TriggerGeometry"]["DisconnectedLayers"] = disconnected_layers_;
+  json_file["TriggerGeometry"]["DisconnectedModules"] = disconnected_modules_;
+  json_file["TriggerGeometry"]["JsonMappingFile"] = json_mapping_file_;
+  json_file["TriggerGeometry"]["L1TLinksMapping"] = L1T_links_mapping_;
+  json_file["TriggerGeometry"]["L1TModulesMapping"] = L1T_modules_mapping_;
+  json_file["TriggerGeometry"]["ScintillatorLinksPerModule"] = scintillator_links_per_module_;
+  json_file["TriggerGeometry"]["ScintillatorModuleSize"] = scintillator_module_size_;
+  json_file["TriggerGeometry"]["ScintillatorTriggerCellSize"] = scintillator_trigger_cell_size_;
+
+}
+void HGCalBackendStage1ParameterExtractor::fillMethodConfig(json& json_file) {
+
+  json_file["TruncationConfig"]["rozMin"] = roz_min_;
+  json_file["TruncationConfig"]["rozMax"] = roz_max_;
+  json_file["TruncationConfig"]["rozBins"] = roz_bins_;
+  json_file["TruncationConfig"]["maxTcsPerBin"] = max_tcs_per_bins_;
+  json_file["TruncationConfig"]["phiSectorEdges"] = phi_edges_;
+}
+
+
+bool HGCalBackendStage1ParameterExtractor::checkMappingConsistency() {
+  // could import that function from GeometryTester instead? (avoiding duplication)
+
+  try {
+    // Set of (subdet,layer,waferU,waferV) with module mapping errors
+    std::set<std::tuple<unsigned, unsigned, int, int>> module_errors;
+    trigger_map_set modules_to_triggercells;
+    trigger_map_set modules_to_cells;
+    trigger_map_set triggercells_to_cells;
+    // EE
+    for (const auto& id : triggerGeometry_->eeGeometry()->getValidDetIds()) {
+      HGCSiliconDetId detid(id);
+      if (!triggerGeometry_->eeTopology().valid(id))
+        continue;
+      // fill trigger cells
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+      // fill modules
+      uint32_t module = 0;
+      try {
+        module = triggerGeometry_->getModuleFromCell(id);
+        triggerGeometry_->getLinksInModule(module);
+      } catch (const std::exception& e) {
+        module_errors.emplace(std::make_tuple(HGCalTriggerModuleDetId(module).triggerSubdetId(),
+                                              HGCalTriggerModuleDetId(module).layer(),
+                                              HGCalTriggerModuleDetId(module).moduleU(),
+                                              HGCalTriggerModuleDetId(module).moduleV()));
+        continue;
+      }
+      itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+
+    // HSi
+    for (const auto& id : triggerGeometry_->hsiGeometry()->getValidDetIds()) {
+      if (!triggerGeometry_->hsiTopology().valid(id))
+        continue;
+      // fill trigger cells
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+      // fill modules
+      uint32_t module = 0;
+      try {
+        module = triggerGeometry_->getModuleFromCell(id);
+        triggerGeometry_->getLinksInModule(module);
+      } catch (const std::exception& e) {
+        module_errors.emplace(std::make_tuple(HGCalTriggerModuleDetId(module).triggerSubdetId(),
+                                              HGCalTriggerModuleDetId(module).layer(),
+                                              HGCalTriggerModuleDetId(module).moduleU(),
+                                              HGCalTriggerModuleDetId(module).moduleV()));
+        continue;
+      }
+      itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+
+    // HSc
+    for (const auto& id : triggerGeometry_->hscGeometry()->getValidDetIds()) {
+      // fill trigger cells
+      unsigned layer = HGCScintillatorDetId(id).layer();
+      if (HGCScintillatorDetId(id).type() != triggerGeometry_->hscTopology().dddConstants().getTypeTrap(layer)) {
+        std::cout << "Sci cell type = " << HGCScintillatorDetId(id).type()
+                  << " != " << triggerGeometry_->hscTopology().dddConstants().getTypeTrap(layer) << "\n";
+      }
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+      // fill modules
+      uint32_t module = triggerGeometry_->getModuleFromCell(id);
+      if (module != 0) {
+        itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
+        itr_insert.first->second.emplace(id);
+      }
+    }
+
+    // NOSE
+    if (triggerGeometry_->isWithNoseGeometry()) {
+      for (const auto& id : triggerGeometry_->noseGeometry()->getValidDetIds()) {
+        if (!triggerGeometry_->noseTopology().valid(id))
+          continue;
+        // fill trigger cells
+        uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+        auto itr_insert = triggercells_to_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+        itr_insert.first->second.emplace(id);
+        // fill modules
+        uint32_t module = triggerGeometry_->getModuleFromCell(id);
+        if (module != 0) {
+          itr_insert = modules_to_cells.emplace(module, std::unordered_set<uint32_t>());
+          itr_insert.first->second.emplace(id);
+        }
+      }
+    }
+
+    if (module_errors.size() > 0) {
+      throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: Found  module mapping problems. Check the produced "
+	"tree to see the list of problematic wafers";
+    }
+
+    edm::LogPrint("TriggerCellCheck") << "Checking cell -> trigger cell -> cell consistency";
+    // Loop over trigger cells
+    for (const auto& triggercell_cells : triggercells_to_cells) {
+      DetId id(triggercell_cells.first);
+
+      // fill modules
+      uint32_t module = triggerGeometry_->getModuleFromTriggerCell(id);
+      if (module != 0) {
+        auto itr_insert = modules_to_triggercells.emplace(module, std::unordered_set<uint32_t>());
+        itr_insert.first->second.emplace(id);
+      }
+
+      // Check consistency of cells included in trigger cell
+      HGCalTriggerGeometryBase::geom_set cells_geom = triggerGeometry_->getCellsFromTriggerCell(id);
+      const auto& cells = triggercell_cells.second;
+      for (auto cell : cells) {
+        if (cells_geom.find(cell) == cells_geom.end()) {
+          if (id.det() == DetId::HGCalHSc) {
+            edm::LogProblem("BadTriggerCell")
+	      << "Error: \n Cell " << cell << "(" << HGCScintillatorDetId(cell)
+	      << ")\n has not been found in \n trigger cell " << HGCScintillatorDetId(id);
+            std::stringstream output;
+            output << " Available cells are:\n";
+            for (auto cell_geom : cells_geom)
+              output << "     " << HGCScintillatorDetId(cell_geom) << "\n";
+            edm::LogProblem("BadTriggerCell") << output.str();
+          } else if (HFNoseTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HFNoseTrigger) {
+            edm::LogProblem("BadTriggerCell")
+	      << "Error: \n Cell " << cell << "(" << HFNoseDetId(cell) << ")\n has not been found in \n trigger cell "
+	      << HFNoseTriggerDetId(triggercell_cells.first);
+            std::stringstream output;
+            output << " Available cells are:\n";
+            for (auto cell_geom : cells_geom)
+              output << "     " << HFNoseDetId(cell_geom) << "\n";
+            edm::LogProblem("BadTriggerCell") << output.str();
+          } else if (HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalEETrigger ||
+                     HGCalTriggerDetId(id).subdet() == HGCalTriggerSubdetector::HGCalHSiTrigger) {
+            edm::LogProblem("BadTriggerCell")
+	      << "Error: \n Cell " << cell << "(" << HGCSiliconDetId(cell)
+	      << ")\n has not been found in \n trigger cell " << HGCalTriggerDetId(triggercell_cells.first);
+            std::stringstream output;
+            output << " Available cells are:\n";
+            for (auto cell_geom : cells_geom)
+              output << "     " << HGCSiliconDetId(cell_geom) << "\n";
+            edm::LogProblem("BadTriggerCell") << output.str();
+          } else {
+            edm::LogProblem("BadTriggerCell")
+	      << "Unknown detector type " << id.det() << " " << id.subdetId() << " " << id.rawId() << "\n";
+            edm::LogProblem("BadTriggerCell") << " cell " << std::hex << cell << std::dec << " "
+                                              << "\n";
+            edm::LogProblem("BadTriggerCell")
+	      << "Cell ID " << HGCSiliconDetId(cell) << " or " << HFNoseDetId(cell) << "\n";
+          }
+          throw cms::Exception("BadGeometry")
+	    << "HGCalTriggerGeometry: Found inconsistency in cell <-> trigger cell mapping";
+        }
+      }
+    }
+    edm::LogPrint("ModuleCheck") << "Checking trigger cell -> module -> trigger cell consistency";
+    // Loop over modules
+    for (const auto& module_triggercells : modules_to_triggercells) {
+      HGCalTriggerModuleDetId id(module_triggercells.first);
+      // Check consistency of trigger cells included in module
+      HGCalTriggerGeometryBase::geom_set triggercells_geom = triggerGeometry_->getTriggerCellsFromModule(id);
+      const auto& triggercells = module_triggercells.second;
+      for (auto cell : triggercells) {
+        if (triggercells_geom.find(cell) == triggercells_geom.end()) {
+          if (id.triggerSubdetId() == HGCalTriggerSubdetector::HGCalHScTrigger) {
+            HGCScintillatorDetId cellid(cell);
+            edm::LogProblem("BadModule") << "Error: \n Trigger cell " << cell << "(" << cellid
+                                         << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
+            std::stringstream output;
+            output << " Available trigger cells are:\n";
+            for (auto cell_geom : triggercells_geom) {
+              output << "     " << HGCScintillatorDetId(cell_geom) << "\n";
+            }
+            edm::LogProblem("BadModule") << output.str();
+            throw cms::Exception("BadGeometry")
+	      << "HGCalTriggerGeometry: Found inconsistency in trigger cell <->  module mapping";
+          } else if (id.triggerSubdetId() == HGCalTriggerSubdetector::HFNoseTrigger) {
+            HFNoseTriggerDetId cellid(cell);
+            edm::LogProblem("BadModule") << "Error : \n Trigger cell " << cell << "(" << cellid
+                                         << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
+            std::stringstream output;
+            output << " Available trigger cells are:\n";
+            for (auto cell_geom : triggercells_geom) {
+              output << "     " << HFNoseTriggerDetId(cell_geom) << "\n";
+            }
+            edm::LogProblem("BadModule") << output.str();
+            throw cms::Exception("BadGeometry")
+	      << "HGCalTriggerGeometry: Found inconsistency in trigger cell <->  module mapping";
+          } else {
+            HGCalTriggerDetId cellid(cell);
+            edm::LogProblem("BadModule") << "Error : \n Trigger cell " << cell << "(" << cellid
+                                         << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
+            std::stringstream output;
+            output << " Available trigger cells are:\n";
+            for (auto cell_geom : triggercells_geom) {
+              output << "     " << HGCalTriggerDetId(cell_geom) << "\n";
+            }
+            edm::LogProblem("BadModule") << output.str();
+            throw cms::Exception("BadGeometry")
+	      << "HGCalTriggerGeometry: Found inconsistency in trigger cell <->  module mapping";
+          }
+        }
+      }
+    }
+    edm::LogPrint("ModuleCheck") << "Checking cell -> module -> cell consistency";
+    for (const auto& module_cells : modules_to_cells) {
+      HGCalTriggerModuleDetId id(module_cells.first);
+      // Check consistency of cells included in module
+      HGCalTriggerGeometryBase::geom_set cells_geom = triggerGeometry_->getCellsFromModule(id);
+      const auto& cells = module_cells.second;
+      for (auto cell : cells) {
+        if (cells_geom.find(cell) == cells_geom.end()) {
+          if (id.triggerSubdetId() == HGCalTriggerSubdetector::HGCalHScTrigger) {
+            edm::LogProblem("BadModule") << "Error: \n Cell " << cell << "(" << HGCScintillatorDetId(cell)
+                                         << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
+          } else if (id.triggerSubdetId() == HGCalTriggerSubdetector::HFNoseTrigger) {
+            edm::LogProblem("BadModule") << "Error: \n Cell " << cell << "(" << HFNoseDetId(cell)
+                                         << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
+          } else {
+            edm::LogProblem("BadModule") << "Error: \n Cell " << cell << "(" << HGCSiliconDetId(cell)
+                                         << ")\n has not been found in \n module " << HGCalTriggerModuleDetId(id);
+          }
+          std::stringstream output;
+          output << " Available cells are:\n";
+          for (auto cell_geom : cells_geom) {
+            output << cell_geom << " ";
+          }
+          edm::LogProblem("BadModule") << output.str();
+          throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: Found inconsistency in cell <-> module mapping";
+        }
+      }
+    }
+
+    // Filling Stage 1 FPGA -> modules
+
+    edm::LogPrint("ModuleCheck") << "Checking module -> stage-1 -> module consistency";
+    trigger_map_set stage1_to_modules;
+    for (const auto& module_tc : modules_to_triggercells) {
+      HGCalTriggerModuleDetId id(module_tc.first);
+      HGCalTriggerGeometryBase::geom_set lpgbts = triggerGeometry_->getLpgbtsFromModule(id);
+      if (lpgbts.size() == 0)
+        continue;  //Module is not connected to an lpGBT and therefore not to a Stage 1 FPGA
+      uint32_t stage1 = 0;
+      for (const auto& lpgbt : lpgbts) {
+        uint32_t stage1_tmp = triggerGeometry_->getStage1FpgaFromLpgbt(lpgbt);
+        if (stage1 != 0 && stage1_tmp != stage1) {
+          throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: Module " << HGCalTriggerModuleDetId(id)
+                                              << " is split is split into more than one Stage-1 FPGA";
+        }
+        stage1 = stage1_tmp;
+      }
+      auto itr_insert = stage1_to_modules.emplace(stage1, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+    // checking S1 -> module consistency
+
+    for (const auto& stage1_modules : stage1_to_modules) {
+      HGCalTriggerBackendDetId stage1(stage1_modules.first);
+      HGCalTriggerGeometryBase::geom_set modules_geom;
+      // Check consistency of modules going to Stage-1 FPGA
+      HGCalTriggerGeometryBase::geom_set lpgbts = triggerGeometry_->getLpgbtsFromStage1Fpga(stage1);
+      for (const auto& lpgbt : lpgbts) {
+        HGCalTriggerGeometryBase::geom_set modules = triggerGeometry_->getModulesFromLpgbt(lpgbt);
+        modules_geom.insert(modules.begin(), modules.end());
+      }
+      const auto& modules = stage1_modules.second;
+      for (auto module : modules) {
+        if (modules_geom.find(module) == modules_geom.end()) {
+          edm::LogProblem("BadStage1") << "Error: \n Module " << module << "(" << HGCalTriggerModuleDetId(module)
+                                       << ")\n has not been found in \n stage-1 " << HGCalTriggerBackendDetId(stage1);
+          std::stringstream output;
+          output << "   Available modules are:\n";
+          for (auto module_geom : modules_geom) {
+            output << module_geom << " ";
+          }
+          output << "   Connected lpgbts are:\n";
+          for (auto lpgbt : lpgbts) {
+            output << lpgbt << " ";
+          }
+          edm::LogProblem("BadStage1") << output.str();
+          throw cms::Exception("BadGeometry")
+	    << "HGCalTriggerGeometry: Found inconsistency in Stage1 <-> module mapping";
+        }
+      }
+    }
+
+    // Filling Stage 2 FPGA -> Stage 1 FPGA
+
+    edm::LogPrint("ModuleCheck") << "Checking Stage 1 -> Stage 2 -> Stage 1 consistency";
+    trigger_map_set stage2_to_stage1;
+    for (const auto& stage1 : stage1_to_modules) {
+      HGCalTriggerBackendDetId id(stage1.first);
+      HGCalTriggerGeometryBase::geom_set stage2FPGAs = triggerGeometry_->getStage2FpgasFromStage1Fpga(id);
+      for (const auto& stage2 : stage2FPGAs) {
+        auto itr_insert = stage2_to_stage1.emplace(stage2, std::unordered_set<uint32_t>());
+        itr_insert.first->second.emplace(id);
+      }
+    }
+    // checking S1 -> S2 consistency
+
+    for (const auto& stage2_modules : stage2_to_stage1) {
+      HGCalTriggerBackendDetId stage2(stage2_modules.first);
+
+      // Check consistency of Stage-1 FPGA going to Stage 2 FPGA
+      HGCalTriggerGeometryBase::geom_set stage1FPGAs = triggerGeometry_->getStage1FpgasFromStage2Fpga(stage2);
+
+      const auto& stage1fpgas = stage2_modules.second;
+
+      for (auto stage1fpga : stage1fpgas) {
+        if (stage1FPGAs.find(stage1fpga) == stage1FPGAs.end()) {
+          edm::LogProblem("BadStage2") << "Error: \n Stage-1 FPGA " << stage1fpga << "("
+                                       << HGCalTriggerBackendDetId(stage1fpga)
+                                       << ")\n has not been found in \n Stage-2 " << HGCalTriggerBackendDetId(stage2);
+          std::stringstream output;
+          output << "\n   Available Stage-1 FPGAs are:\n";
+          for (auto stage1FPGA : stage1FPGAs) {
+            output << HGCalTriggerBackendDetId(stage1FPGA) << "\n";
+          }
+          edm::LogProblem("BadStage2") << output.str();
+          throw cms::Exception("BadGeometry")
+	    << "HGCalTriggerGeometry: Found inconsistency in Stage2 <-> Stage1 mapping";
+        }
+      }
+    }
+
+  } catch (const cms::Exception& e) {
+    edm::LogWarning("HGCalTriggerGeometryTester")
+      << "Problem with the trigger geometry detected. Only the basic cells tree will be filled\n";
+    edm::LogWarning("HGCalTriggerGeometryTester") << e.message() << "\n";
+    return false;
+  }
+  return true;
+}
+
+
+
+
+void HGCalBackendStage1ParameterExtractor::fillTriggerGeometry(json& json_file)
+{
+  trigger_map_set trigger_cells;
+
+  // EE
+  std::cout << "Checking EE geometry\n";
+  for (const auto& id : triggerGeometry_->eeGeometry()->getValidDetIds()) {
+    HGCSiliconDetId detid(id);
+    if (!triggerGeometry_->eeTopology().valid(id))
+      continue;
+    // fill trigger cells
+    if (!no_trigger_) {
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+  }
+  std::cout << "Checking HSi geometry\n";
+  for (const auto& id : triggerGeometry_->hsiGeometry()->getValidDetIds()) {
+    HGCSiliconDetId detid(id);
+    if (!triggerGeometry_->hsiTopology().valid(id))
+      continue;
+    // fill trigger cells
+    if (!no_trigger_) {
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+  }
+  std::cout << "Checking HSc geometry\n";
+  for (const auto& id : triggerGeometry_->hscGeometry()->getValidDetIds()) {
+    if (!no_trigger_) {
+      uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+      auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+  }
+
+  if (triggerGeometry_->isWithNoseGeometry()) {
+    std::cout << "Checking NOSE geometry\n";
+    for (const auto& id : triggerGeometry_->noseGeometry()->getValidDetIds()) {
+      // fill trigger cells
+      if (!no_trigger_) {
+        uint32_t trigger_cell = triggerGeometry_->getTriggerCellFromCell(id);
+        auto itr_insert = trigger_cells.emplace(trigger_cell, std::unordered_set<uint32_t>());
+        itr_insert.first->second.emplace(id);
+      }
+    }
+  }
+
+  // if problem detected in the trigger geometry, don't produce trigger trees
+  if (no_trigger_)
+    return;
+
+  // Loop over trigger cells
+  edm::LogPrint("JSONFilling") << "Filling JSON map";
+  unsigned i = 0; // countertest
+  for (const auto& triggercell_cells : trigger_cells) {
+
+    DetId id(triggercell_cells.first);
+
+    uint32_t moduleId = triggerGeometry_->getModuleFromTriggerCell(id);
+    if(moduleId==0) continue;
+    HGCalTriggerModuleDetId tc_module(moduleId);
+    if (!(tc_module.isHGCalModuleDetId()) || (tc_module.zside()>0) || (tc_module.sector()!=0)) continue;
+    
+    HGCalTriggerGeometryBase::geom_set lpgbts = triggerGeometry_->getLpgbtsFromModule(moduleId);
+    if (lpgbts.size() == 0)
+      continue;  //Module is not connected to an lpGBT and therefore not to a Stage 1 FPGA
+  
+    // only retrieve mapping for the tested fpga
+    uint32_t fpgaId = triggerGeometry_->getStage1FpgaFromModule(moduleId);
+    HGCalTriggerBackendDetId tc_fpga(fpgaId);
+    if (!(tc_fpga.isStage1FPGA()) || (tc_fpga.sector()!=0) || (tc_fpga.zside()>0)) continue;
+    int fpga_label = tc_fpga.label();
+    if (fpga_label != the_fpga_) continue;
+        
+    int triggerCellSubdet = 0;
+    int triggerCellLayer = 0;
+    int triggerCellUEta = 0;
+    int triggerCellVPhi = 0;
+
+    if (id.det() == DetId::HGCalHSc) {
+      HGCScintillatorDetId id_sc(triggercell_cells.first);
+      triggerCellSubdet = id_sc.subdet();
+      triggerCellLayer = id_sc.layer();
+      triggerCellUEta = id_sc.ietaAbs();
+      triggerCellVPhi = id_sc.iphi();
+    } else if (HFNoseTriggerDetId(triggercell_cells.first).det() == DetId::HGCalTrigger &&
+               HFNoseTriggerDetId(triggercell_cells.first).subdet() == HGCalTriggerSubdetector::HFNoseTrigger/*==0*/) {
+      HFNoseTriggerDetId id_nose_trig(triggercell_cells.first); 
+      triggerCellSubdet = id_nose_trig.subdet();
+      triggerCellLayer = id_nose_trig.layer();
+      triggerCellUEta = id_nose_trig.triggerCellU();
+      triggerCellVPhi = id_nose_trig.triggerCellV();
+    } else {
+      HGCalTriggerDetId id_si_trig(triggercell_cells.first);
+      triggerCellSubdet = id_si_trig.subdet();
+      triggerCellLayer = id_si_trig.layer();
+      triggerCellUEta = id_si_trig.triggerCellU();
+      triggerCellVPhi = id_si_trig.triggerCellV();
+    }
+    
+    //tc id
+    uint32_t tce = triggerCellUEta ,tcp = triggerCellVPhi;
+    if(triggerCellSubdet==10){ // HGCalHSc
+      tcp = (triggerCellVPhi - 1)%4;
+      if (triggerCellUEta<=3) { 
+	tce = triggerCellUEta;
+      } else if(triggerCellUEta<=9) {
+	tce = triggerCellUEta-4;
+      } else if(triggerCellUEta<=13) {
+	tce = triggerCellUEta-10;
+      } else if(triggerCellUEta<=17) {
+	tce = triggerCellUEta-14;
+      } else {
+	tce = triggerCellUEta-18;
+      }
+    }
+
+    uint32_t tcaddress;
+    if (triggerCellSubdet==10) { //HGCalHSc(10)
+      tcaddress = (int(tce)<<2) + int(tcp);
+    } else { //HGCalHSiTrigger(2) or HGCalEE(1)
+      tcaddress = tc_coord_uv_.find(std::make_pair(tce,tcp))->second; 
+    }
+    
+    std::unordered_map<std::string, unsigned> TCinfo {
+      {"subdet", triggerCellSubdet},
+      {"layer", triggerCellLayer},
+      {"ueta", tce},
+      {"vphi", tcp}
+    };
+    
+    if(i%100==0)
+      std::cout << i << " TC filled" << std::endl;
+    i++;
+    
+    json_file["TCMap"]["module_hash"][std::to_string(moduleId)]["tc_id"][std::to_string(tcaddress)] = TCinfo;
+  
+  }
+}
+
+void HGCalBackendStage1ParameterExtractor::analyze(const edm::Event& e, const edm::EventSetup& es) {}
+
+// define this as a plug-in
+DEFINE_FWK_MODULE(HGCalBackendStage1ParameterExtractor);

--- a/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
@@ -63,6 +63,8 @@ from re import match
 geomXMLcontent = process.XMLIdealGeometryESSource.geomXMLFiles.value()
 hgcal_xml = 'Geometry/HGCalCommonData/data/hgcal/v.*/hgcal.xml'
 geometry_version = list(filter(lambda v: match(hgcal_xml,v), geomXMLcontent))
+if len(geometry_version) == 0:
+    raise ValueError('No xml file could be found for geometry version extraction')
 if len(geometry_version) > 1:
     raise ValueError('More than one xml file could be found for geometry version extraction')
 geometry_version = geometry_version[0].split('/')[4]

--- a/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
@@ -62,7 +62,10 @@ fpga_id = 1
 from re import match
 geomXMLcontent = process.XMLIdealGeometryESSource.geomXMLFiles.value()
 hgcal_xml = 'Geometry/HGCalCommonData/data/hgcal/v.*/hgcal.xml'
-geometry_version = "".join(filter(lambda v: match(hgcal_xml,v), geomXMLcontent)).split('/')[4]
+geometry_version = list(filter(lambda v: match(hgcal_xml,v), geomXMLcontent))
+if len(geometry_version) > 1:
+    raise ValueError('More than one xml file could be found for geometry version extraction')
+geometry_version = geometry_version[0].split('/')[4]
 
 process.hgcalbackendstage1parameterextractor = cms.EDAnalyzer(
     "HGCalBackendStage1ParameterExtractor",

--- a/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
@@ -59,8 +59,10 @@ ordered_tcv = [0, 1, 1, 0, 2, 3, 3, 2, 2, 3, 3, 2, 0, 1, 1, 0, 7, 7, 6, 6, 7, 7,
 fpga_id = 1
 
 # geometry version
-from Geometry.CMSCommonData.cmsExtendedGeometry2026D49XML_cfi import XMLIdealGeometryESSource
-geometry_version = [s for s in XMLIdealGeometryESSource.geomXMLFiles.value() if "Geometry/HGCalCommonData/data/hgcal/" in s][0].replace('Geometry/HGCalCommonData/data/hgcal/','').replace('/hgcal.xml','')
+from re import match
+geomXMLcontent = process.XMLIdealGeometryESSource.geomXMLFiles.value()
+hgcal_xml = 'Geometry/HGCalCommonData/data/hgcal/v.*/hgcal.xml'
+geometry_version = "".join(filter(lambda v: match(hgcal_xml,v), geomXMLcontent)).split('/')[4]
 
 process.hgcalbackendstage1parameterextractor = cms.EDAnalyzer(
     "HGCalBackendStage1ParameterExtractor",

--- a/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
@@ -22,7 +22,6 @@ process.load('Configuration.StandardSequences.DigiToRaw_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
-
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
@@ -59,10 +58,14 @@ ordered_tcv = [0, 1, 1, 0, 2, 3, 3, 2, 2, 3, 3, 2, 0, 1, 1, 0, 7, 7, 6, 6, 7, 7,
 # ID of tested FPGA
 fpga_id = 1
 
+# geometry version
+from Geometry.CMSCommonData.cmsExtendedGeometry2026D49XML_cfi import XMLIdealGeometryESSource
+geometry_version = [s for s in XMLIdealGeometryESSource.geomXMLFiles.value() if "Geometry/HGCalCommonData/data/hgcal/" in s][0].replace('Geometry/HGCalCommonData/data/hgcal/','').replace('/hgcal.xml','')
+
 process.hgcalbackendstage1parameterextractor = cms.EDAnalyzer(
     "HGCalBackendStage1ParameterExtractor",
     outJSONname = cms.string("geometryConfig_backendStage1.json"),
-    testedFpga = cms.uint32(fpga_id), #
+    testedFpga = cms.int32(fpga_id),
     BackendStage1Params = stage1truncation_proc.truncation_parameters,
     TriggerGeometryParam = process.hgcalTriggerGeometryESProducer.TriggerGeometry,
     TCcoord_UV = cms.PSet(
@@ -70,7 +73,7 @@ process.hgcalbackendstage1parameterextractor = cms.EDAnalyzer(
         TCv = cms.vuint32(ordered_tcv)
     ),
     MetaData = cms.PSet(
-        CMSSW_era = cms.string('CMSSW_12_3_0_pre4')
+        geometryVersion = cms.string(geometry_version)
     ),
 )
 

--- a/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
@@ -63,10 +63,9 @@ from re import match
 geomXMLcontent = process.XMLIdealGeometryESSource.geomXMLFiles.value()
 hgcal_xml = 'Geometry/HGCalCommonData/data/hgcal/v.*/hgcal.xml'
 geometry_version = list(filter(lambda v: match(hgcal_xml,v), geomXMLcontent))
-if len(geometry_version) == 0:
-    raise ValueError('No xml file could be found for geometry version extraction')
-if len(geometry_version) > 1:
-    raise ValueError('More than one xml file could be found for geometry version extraction')
+if len(geometry_version) != 1:
+    raise ValueError('Can\'t find geometry version - expected one xml file, but got {}'.format(len(geometry_version)))
+
 geometry_version = geometry_version[0].split('/')[4]
 
 process.hgcalbackendstage1parameterextractor = cms.EDAnalyzer(

--- a/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
@@ -1,0 +1,156 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
+process = cms.Process('SIM',Phase2C9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+'''
+process.MessageLogger = cms.Service("MessageLogger",
+                                    destinations   = cms.untracked.vstring('myDebugOutputFile'),
+                                    myDebugOutputFile = cms.untracked.PSet(
+                                        threshold = cms.untracked.string('DEBUG'),      #4
+                                        default = cms.untracked.PSet(                   
+                                            limit = cms.untracked.int32(-1) #5
+                                        ),
+                                        debugModules = cms.untracked.vstring(                            #6
+                                            'hgcalbackendstage1parameterextractor')           #7
+                                    )                                                                       #8
+                                )
+'''
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
+    fileName = cms.untracked.string('file:junk.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+# Additional output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("test_triggergeom.root")
+    )
+
+
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
+
+process.generator = cms.EDProducer("FlatRandomPtGunProducer",
+    PGunParameters = cms.PSet(
+        MaxPt = cms.double(10.01),
+        MinPt = cms.double(9.99),
+        PartID = cms.vint32(13),
+        MaxEta = cms.double(2.5),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-2.5),
+        MinPhi = cms.double(-3.14159265359)
+    ),
+    Verbosity = cms.untracked.int32(0),
+    psethack = cms.string('single electron pt 10'),
+    AddAntiParticle = cms.bool(True),
+    firstRun = cms.untracked.uint32(1)
+)
+
+process.mix.digitizers = cms.PSet(process.theDigitizersValid)
+
+# load HGCAL TPG simulation
+#process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitivesNew_cff')
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen)
+process.simulation_step = cms.Path(process.psim)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.digitisation_step = cms.Path(process.pdigi_valid)
+process.L1simulation_step = cms.Path(process.SimL1Emulator)
+process.digi2raw_step = cms.Path(process.DigiToRaw)
+
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)
+
+# Eventually modify default geometry parameters
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp3
+process = custom_geometry_V11_Imp3(process)
+
+# Fetch stage 1 truncation parameters from correct config
+from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import stage1truncation_proc
+
+# ordered u/v coordinated of TCs in a module, for consistent TC index definition
+ordered_tcu = [4, 5, 4, 3, 6, 7, 6, 5, 4, 5, 4, 3, 2, 3, 2, 1, 7, 6, 6, 7, 5, 4, 4, 5, 5, 4, 4, 5, 7, 6, 6, 7, 0, 0, 1, 1, 0, 0, 1, 1, 2, 2, 3, 3, 2, 2, 3, 3]
+ordered_tcv = [0, 1, 1, 0, 2, 3, 3, 2, 2, 3, 3, 2, 0, 1, 1, 0, 7, 7, 6, 6, 7, 7, 6, 6, 5, 5, 4, 4, 5, 5, 4, 4, 3, 2, 3, 4, 1, 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 6]
+
+
+process.hgcalbackendstage1parameterextractor = cms.EDAnalyzer(
+    "HGCalBackendStage1ParameterExtractor",
+    outJSONname = cms.string("test.json"),
+    testedFpga = cms.int32(1),
+    BackendStage1Params = stage1truncation_proc,
+    TriggerGeometryParam = process.hgcalTriggerGeometryESProducer.TriggerGeometry,
+    TCcoord_UV = cms.PSet(
+        TCu = cms.vuint32(ordered_tcu),
+        TCv = cms.vuint32(ordered_tcv)
+    ),
+    MetaData = cms.PSet(
+        CMSSW_version = cms.string('CMSSW_12_3_0_pre4')
+    ),
+)
+
+process.test_step = cms.Path(process.hgcalbackendstage1parameterextractor)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.test_step,process.endjob_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+    getattr(process,path)._seq = process.generator * getattr(process,path)._seq
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)

--- a/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
@@ -22,6 +22,7 @@ process.load('Configuration.StandardSequences.DigiToRaw_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
@@ -42,8 +43,7 @@ process.configurationMetadata = cms.untracked.PSet(
 # Output definition
 
 # load HGCAL TPG simulation
-#process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
-process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitivesNew_cff')
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 
 # Eventually modify default geometry parameters
 from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp3
@@ -62,15 +62,15 @@ fpga_id = 1
 process.hgcalbackendstage1parameterextractor = cms.EDAnalyzer(
     "HGCalBackendStage1ParameterExtractor",
     outJSONname = cms.string("geometryConfig_backendStage1.json"),
-    testedFpga = cms.int32(fpga_id), #
-    BackendStage1Params = stage1truncation_proc,
+    testedFpga = cms.uint32(fpga_id), #
+    BackendStage1Params = stage1truncation_proc.truncation_parameters,
     TriggerGeometryParam = process.hgcalTriggerGeometryESProducer.TriggerGeometry,
     TCcoord_UV = cms.PSet(
         TCu = cms.vuint32(ordered_tcu),
         TCv = cms.vuint32(ordered_tcv)
     ),
     MetaData = cms.PSet(
-        CMSSW_version = cms.string('CMSSW_12_3_0_pre4')
+        CMSSW_era = cms.string('CMSSW_12_3_0_pre4')
     ),
 )
 

--- a/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalBackendStage1ParameterExtractor_cfg.py
@@ -22,20 +22,6 @@ process.load('Configuration.StandardSequences.DigiToRaw_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
-'''
-process.MessageLogger = cms.Service("MessageLogger",
-                                    destinations   = cms.untracked.vstring('myDebugOutputFile'),
-                                    myDebugOutputFile = cms.untracked.PSet(
-                                        threshold = cms.untracked.string('DEBUG'),      #4
-                                        default = cms.untracked.PSet(                   
-                                            limit = cms.untracked.int32(-1) #5
-                                        ),
-                                        debugModules = cms.untracked.vstring(                            #6
-                                            'hgcalbackendstage1parameterextractor')           #7
-                                    )                                                                       #8
-                                )
-'''
-
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
@@ -44,7 +30,6 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("EmptySource")
 
 process.options = cms.untracked.PSet(
-
 )
 
 # Production Info
@@ -56,82 +41,28 @@ process.configurationMetadata = cms.untracked.PSet(
 
 # Output definition
 
-process.FEVTDEBUGoutput = cms.OutputModule("PoolOutputModule",
-    splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
-    outputCommands = process.FEVTDEBUGHLTEventContent.outputCommands,
-    fileName = cms.untracked.string('file:junk.root'),
-    dataset = cms.untracked.PSet(
-        filterName = cms.untracked.string(''),
-        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW')
-    ),
-    SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('generation_step')
-    )
-)
-
-# Additional output definition
-process.TFileService = cms.Service(
-    "TFileService",
-    fileName = cms.string("test_triggergeom.root")
-    )
-
-
-
-# Other statements
-process.genstepfilter.triggerConditions=cms.vstring("generation_step")
-from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
-
-process.generator = cms.EDProducer("FlatRandomPtGunProducer",
-    PGunParameters = cms.PSet(
-        MaxPt = cms.double(10.01),
-        MinPt = cms.double(9.99),
-        PartID = cms.vint32(13),
-        MaxEta = cms.double(2.5),
-        MaxPhi = cms.double(3.14159265359),
-        MinEta = cms.double(-2.5),
-        MinPhi = cms.double(-3.14159265359)
-    ),
-    Verbosity = cms.untracked.int32(0),
-    psethack = cms.string('single electron pt 10'),
-    AddAntiParticle = cms.bool(True),
-    firstRun = cms.untracked.uint32(1)
-)
-
-process.mix.digitizers = cms.PSet(process.theDigitizersValid)
-
 # load HGCAL TPG simulation
 #process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitivesNew_cff')
-
-# Path and EndPath definitions
-process.generation_step = cms.Path(process.pgen)
-process.simulation_step = cms.Path(process.psim)
-process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
-process.digitisation_step = cms.Path(process.pdigi_valid)
-process.L1simulation_step = cms.Path(process.SimL1Emulator)
-process.digi2raw_step = cms.Path(process.DigiToRaw)
-
-process.endjob_step = cms.EndPath(process.endOfProcess)
-process.FEVTDEBUGoutput_step = cms.EndPath(process.FEVTDEBUGoutput)
 
 # Eventually modify default geometry parameters
 from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp3
 process = custom_geometry_V11_Imp3(process)
 
-# Fetch stage 1 truncation parameters from correct config
+# Fetch stage 1 truncation parameters
 from L1Trigger.L1THGCal.hgcalBackEndLayer1Producer_cfi import stage1truncation_proc
 
 # ordered u/v coordinated of TCs in a module, for consistent TC index definition
 ordered_tcu = [4, 5, 4, 3, 6, 7, 6, 5, 4, 5, 4, 3, 2, 3, 2, 1, 7, 6, 6, 7, 5, 4, 4, 5, 5, 4, 4, 5, 7, 6, 6, 7, 0, 0, 1, 1, 0, 0, 1, 1, 2, 2, 3, 3, 2, 2, 3, 3]
 ordered_tcv = [0, 1, 1, 0, 2, 3, 3, 2, 2, 3, 3, 2, 0, 1, 1, 0, 7, 7, 6, 6, 7, 7, 6, 6, 5, 5, 4, 4, 5, 5, 4, 4, 3, 2, 3, 4, 1, 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 6]
 
+# ID of tested FPGA
+fpga_id = 1
 
 process.hgcalbackendstage1parameterextractor = cms.EDAnalyzer(
     "HGCalBackendStage1ParameterExtractor",
-    outJSONname = cms.string("test.json"),
-    testedFpga = cms.int32(1),
+    outJSONname = cms.string("geometryConfig_backendStage1.json"),
+    testedFpga = cms.int32(fpga_id), #
     BackendStage1Params = stage1truncation_proc,
     TriggerGeometryParam = process.hgcalTriggerGeometryESProducer.TriggerGeometry,
     TCcoord_UV = cms.PSet(
@@ -143,13 +74,12 @@ process.hgcalbackendstage1parameterextractor = cms.EDAnalyzer(
     ),
 )
 
+# Path and EndPath definitions
 process.test_step = cms.Path(process.hgcalbackendstage1parameterextractor)
+process.endjob_step = cms.EndPath(process.endOfProcess)
 
 # Schedule definition
 process.schedule = cms.Schedule(process.test_step,process.endjob_step)
-# filter all path with the production filter sequence
-for path in process.paths:
-    getattr(process,path)._seq = process.generator * getattr(process,path)._seq
 
 # Add early deletion of temporary data products to reduce peak memory need
 from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete


### PR DESCRIPTION
#### PR description:

The PR introduced a new analyzer, `HGCalBackendStage1ParameterExtractor.cc`, that reads the HGCal trigger geometry, and backend stage 1 parametrization from the relevant modules in CMSSW. It then saves the relevant information for the configuration of the firmware and emulator tests of a given FPGA (requested for now in the python cfg).

With the information currently saved, the output JSON file is of manageable size (~5MB), and adding more information should not be too problematic.