### PR TITLE
Trigger module det id bit assignment

### DIFF
--- a/DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h
@@ -89,7 +89,7 @@ public:
   static const int kHGCalModuleVMask = 0xF;
   static const int kHGCalModuleUOffset = 4;
   static const int kHGCalModuleUMask = 0xF;
-  static const int kHGCalLayerOffset = 9;
+  static const int kHGCalLayerOffset = 8;
   static const int kHGCalLayerMask = 0x1F;
   static const int kHGCalTriggerSubdetOffset = 13;
   static const int kHGCalTriggerSubdetMask = 0x3;

--- a/DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h
@@ -6,23 +6,24 @@
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 
 /* \brief description of the bit assigment
-   [0:3]  u-coordinate of the silicon module (u-axis points along -x axis)
-          or eta-coordinate of the scintillator module
-   [4:7]  v-coordinate of the silicon module (v-axis points 60-degree wrt x-axis)
+   [0:3]  v-coordinate of the silicon module (v-axis points 60-degree wrt x-axis)
           or phi-coordinate of the scintillator module
-   [8:9] sector (0,1,2 counter-clockwise from u-axis)
+   [4:7]  u-coordinate of the silicon module (u-axis points along -x axis)
+          or eta-coordinate of the scintillator module
+   [8:12] layer number
+   [13:14] Trigger Subdetector Type(HGCEE/HGCHEF/HGCHEB/HFNose)
 
-   [10:13] reserved for future use
+   [15:18] reserved for future use
 
-   [14:18] layer number 
-   [19:20] Type (0 fine divisions of wafer with 120 mum thick silicon
+   [19:20] sector (0,1,2 counter-clockwise from u-axis)
+
+   [21:22] Type (0 fine divisions of wafer with 120 mum thick silicon
                  1 coarse divisions of wafer with 200 mum thick silicon
                  2 coarse divisions of wafer with 300 mum thick silicon
                  0 fine divisions of scintillators
                  1 coarse divisions of scintillators)
 
-   [21:21] z-side (0 for +z; 1 for -z)
-   [22:23] Trigger Subdetector Type(HGCEE/HGCHEF/HGCHEB/HFNose) 
+   [23:23] z-side (0 for +z; 1 for -z)
    [24:24] Class identifier (0 for HGCalTriggerModuleDetID, 1 for HGCalTriggerBackendDetID)
    [25:27] Subdetector Type (HGCTrigger)
    [28:31] Detector type (Forward)
@@ -84,22 +85,23 @@ public:
 
   static const HGCalTriggerModuleDetId Undefined;
 
-  static const int kHGCalModuleUOffset = 0;
-  static const int kHGCalModuleUMask = 0xF;
-  static const int kHGCalModuleVOffset = 4;
+  static const int kHGCalModuleVOffset = 0;
   static const int kHGCalModuleVMask = 0xF;
-  static const int kHGCalSectorOffset = 8;
-  static const int kHGCalSectorMask = 0x3;
-  static const int kHGCalLayerOffset = 14;
+  static const int kHGCalModuleUOffset = 4;
+  static const int kHGCalModuleUMask = 0xF;
+  static const int kHGCalLayerOffset = 9;
   static const int kHGCalLayerMask = 0x1F;
-  static const int kHGCalTypeOffset = 19;
-  static const int kHGCalTypeMask = 0x3;
-  static const int kHGCalZsideOffset = 21;
-  static const int kHGCalZsideMask = 0x1;
-  static const int kHGCalTriggerSubdetOffset = 22;
+  static const int kHGCalTriggerSubdetOffset = 13;
   static const int kHGCalTriggerSubdetMask = 0x3;
+  static const int kHGCalSectorOffset = 19;
+  static const int kHGCalSectorMask = 0x3;
+  static const int kHGCalTypeOffset = 21;
+  static const int kHGCalTypeMask = 0x3;
+  static const int kHGCalZsideOffset = 23;
+  static const int kHGCalZsideMask = 0x1;
   static const int kHGCalTriggerClassIdentifierOffset = 24;
   static const int kHGCalTriggerClassIdentifierMask = 0x1;
+
 };
 
 std::ostream& operator<<(std::ostream&, const HGCalTriggerModuleDetId& id);


### PR DESCRIPTION
This modification allows for a much easier comparison of module ID with the ID used for S1 firmware. Now need to retrieve first 14 bits instead of fetching separately all required information.