### PR TITLE
FP compression now working in 64-bit

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalVFECompressionImpl.h
+++ b/L1Trigger/L1THGCal/interface/HGCalVFECompressionImpl.h
@@ -10,8 +10,8 @@ class HGCalVFECompressionImpl {
 public:
   HGCalVFECompressionImpl(const edm::ParameterSet& conf);
 
-  void compress(const std::unordered_map<uint32_t, uint32_t>&, std::unordered_map<uint32_t, std::array<uint32_t, 2> >&);
-  void compressSingle(const uint32_t value, uint32_t& compressedCode, uint32_t& compressedValue) const;
+  void compress(const std::unordered_map<uint32_t, uint32_t>&, std::unordered_map<uint32_t, std::array<uint64_t, 2> >&);
+  void compressSingle(const uint64_t value, uint32_t& compressedCode, uint64_t& compressedValue) const;
 
 private:
   uint32_t exponentBits_;
@@ -19,7 +19,7 @@ private:
   uint32_t truncationBits_;
   bool rounding_;
   uint32_t saturationCode_;
-  uint32_t saturationValue_;
+  uint64_t saturationValue_;
 };
 
 #endif

--- a/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
+++ b/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
@@ -37,7 +37,7 @@ void HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
   std::vector<HGCalDataFrame> dataframes;
   std::vector<std::pair<DetId, uint32_t>> linearized_dataframes;
   std::unordered_map<uint32_t, uint32_t> tc_payload;
-  std::unordered_map<uint32_t, std::array<uint32_t, 2>> tc_compressed_payload;
+  std::unordered_map<uint32_t, std::array<uint64_t, 2>> tc_compressed_payload;
 
   // Remove disconnected modules and invalid cells
   for (const auto& digiData : digiColl) {
@@ -83,8 +83,8 @@ void HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
   for (const auto& [tc_id, tc_value] : tc_payload) {
     if (tc_value > 0) {
       const auto& [tc_compressed_code, tc_compressed_value] = tc_compressed_payload[tc_id];
-      l1t::HGCalTriggerCell triggerCell(reco::LeafCandidate::LorentzVector(), tc_compressed_value, 0, 0, 0, tc_id);
-      triggerCell.setCompressedCharge(tc_compressed_code);
+      l1t::HGCalTriggerCell triggerCell(reco::LeafCandidate::LorentzVector(), static_cast<int>(tc_compressed_value), 0, 0, 0, tc_id);
+      triggerCell.setCompressedCharge(static_cast<uint32_t>(tc_compressed_code));
       triggerCell.setUncompressedCharge(tc_value);
       GlobalPoint point = geometry()->getTriggerCellPosition(tc_id);
 

--- a/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
+++ b/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
@@ -83,12 +83,16 @@ void HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
   for (const auto& [tc_id, tc_value] : tc_payload) {
     if (tc_value > 0) {
       const auto& [tc_compressed_code, tc_compressed_value] = tc_compressed_payload[tc_id];
-      if (tc_compressed_value > 0xFFFFFFFF)
+
+      if (tc_compressed_value > std::numeric_limits<int>::max())
         edm::LogWarning("CompressedValueDowncasting") << "Compressed value cannot fit into 32-bit word. Downcasting.";
+
       l1t::HGCalTriggerCell triggerCell(
           reco::LeafCandidate::LorentzVector(), static_cast<int>(tc_compressed_value), 0, 0, 0, tc_id);
-      if (tc_compressed_code > 0xFFFFFFFF)
+
+      if (tc_compressed_code > std::numeric_limits<uint32_t>::max())
         edm::LogWarning("CompressedValueDowncasting") << "Compressed code cannot fit into 32-bit word. Downcasting.";
+
       triggerCell.setCompressedCharge(static_cast<uint32_t>(tc_compressed_code));
       triggerCell.setUncompressedCharge(tc_value);
       GlobalPoint point = geometry()->getTriggerCellPosition(tc_id);

--- a/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
+++ b/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
@@ -83,7 +83,8 @@ void HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
   for (const auto& [tc_id, tc_value] : tc_payload) {
     if (tc_value > 0) {
       const auto& [tc_compressed_code, tc_compressed_value] = tc_compressed_payload[tc_id];
-      l1t::HGCalTriggerCell triggerCell(reco::LeafCandidate::LorentzVector(), static_cast<int>(tc_compressed_value), 0, 0, 0, tc_id);
+      l1t::HGCalTriggerCell triggerCell(
+          reco::LeafCandidate::LorentzVector(), static_cast<int>(tc_compressed_value), 0, 0, 0, tc_id);
       triggerCell.setCompressedCharge(static_cast<uint32_t>(tc_compressed_code));
       triggerCell.setUncompressedCharge(tc_value);
       GlobalPoint point = geometry()->getTriggerCellPosition(tc_id);

--- a/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
+++ b/L1Trigger/L1THGCal/plugins/veryfrontend/HGCalVFEProcessorSums.cc
@@ -83,8 +83,12 @@ void HGCalVFEProcessorSums::run(const HGCalDigiCollection& digiColl,
   for (const auto& [tc_id, tc_value] : tc_payload) {
     if (tc_value > 0) {
       const auto& [tc_compressed_code, tc_compressed_value] = tc_compressed_payload[tc_id];
+      if (tc_compressed_value > 0xFFFFFFFF)
+        edm::LogWarning("CompressedValueDowncasting") << "Compressed value cannot fit into 32-bit word. Downcasting.";
       l1t::HGCalTriggerCell triggerCell(
           reco::LeafCandidate::LorentzVector(), static_cast<int>(tc_compressed_value), 0, 0, 0, tc_id);
+      if (tc_compressed_code > 0xFFFFFFFF)
+        edm::LogWarning("CompressedValueDowncasting") << "Compressed code cannot fit into 32-bit word. Downcasting.";
       triggerCell.setCompressedCharge(static_cast<uint32_t>(tc_compressed_code));
       triggerCell.setUncompressedCharge(tc_value);
       GlobalPoint point = geometry()->getTriggerCellPosition(tc_id);

--- a/L1Trigger/L1THGCal/src/HGCalVFECompressionImpl.cc
+++ b/L1Trigger/L1THGCal/src/HGCalVFECompressionImpl.cc
@@ -7,18 +7,18 @@ HGCalVFECompressionImpl::HGCalVFECompressionImpl(const edm::ParameterSet& conf)
       mantissaBits_(conf.getParameter<uint32_t>("mantissaBits")),
       truncationBits_(conf.getParameter<uint32_t>("truncationBits")),
       rounding_(conf.getParameter<bool>("rounding")) {
-  if (((1 << exponentBits_) + mantissaBits_ - 1) >= 32) {
-    throw cms::Exception("CodespaceCannotFit") << "The code space cannot fit into the unsigned 32-bit space.\n";
+  if (((1 << exponentBits_) + mantissaBits_ - 1) >= 64) {
+    throw cms::Exception("CodespaceCannotFit") << "The code space cannot fit into the unsigned 64-bit space.\n";
   }
   saturationCode_ = (1 << (exponentBits_ + mantissaBits_)) - 1;
   saturationValue_ = (exponentBits_ == 0)
                          ? saturationCode_
-                         : ((1 << (mantissaBits_ + truncationBits_ + 1)) - 1) << ((1 << exponentBits_) - 2);
+                         : ((1LL << (mantissaBits_ + truncationBits_ + 1)) - 1) << ((1 << exponentBits_) - 2);
 }
 
-void HGCalVFECompressionImpl::compressSingle(const uint32_t value,
+void HGCalVFECompressionImpl::compressSingle(const uint64_t value,
                                              uint32_t& compressedCode,
-                                             uint32_t& compressedValue) const {
+                                             uint64_t& compressedValue) const {
   // check for saturation
   if (value > saturationValue_) {
     compressedCode = saturationCode_;
@@ -28,8 +28,8 @@ void HGCalVFECompressionImpl::compressSingle(const uint32_t value,
 
   // count bit length
   uint32_t bitlen;
-  uint32_t shifted_value = value >> truncationBits_;
-  uint32_t valcopy = shifted_value;
+  uint64_t shifted_value = value >> truncationBits_;
+  uint64_t valcopy = shifted_value;
   for (bitlen = 0; valcopy != 0; valcopy >>= 1, bitlen++) {
   }
   if (bitlen <= mantissaBits_) {
@@ -40,7 +40,7 @@ void HGCalVFECompressionImpl::compressSingle(const uint32_t value,
 
   // build exponent and mantissa
   const uint32_t exponent = bitlen - mantissaBits_;
-  const uint32_t mantissa = (shifted_value >> (exponent - 1)) & ~(1 << mantissaBits_);
+  const uint64_t mantissa = (shifted_value >> (exponent - 1)) & ~(1LL << mantissaBits_);
 
   // assemble floating-point
   const uint32_t floatval = (exponent << mantissaBits_) | mantissa;
@@ -48,34 +48,34 @@ void HGCalVFECompressionImpl::compressSingle(const uint32_t value,
   // we will never want to round up maximum code here
   if (!rounding_ || floatval == saturationCode_) {
     compressedCode = floatval;
-    compressedValue = ((1 << mantissaBits_) | mantissa) << (exponent - 1);
+    compressedValue = ((1LL << mantissaBits_) | mantissa) << (exponent - 1);
   } else {
-    const bool roundup = ((shifted_value >> (exponent - 2)) & 1) == 1;
+    const bool roundup = ((shifted_value >> (exponent - 2)) & 1LL) == 1LL;
     if (!roundup) {
       compressedCode = floatval;
-      compressedValue = ((1 << mantissaBits_) | mantissa) << (exponent - 1);
+      compressedValue = ((1LL << mantissaBits_) | mantissa) << (exponent - 1);
     } else {
       compressedCode = floatval + 1;
-      uint32_t rmantissa = mantissa + 1;
+      uint64_t rmantissa = mantissa + 1;
       uint32_t rexponent = exponent;
-      if (rmantissa >= (1U << mantissaBits_)) {
+      if (rmantissa >= (1ULL << mantissaBits_)) {
         rexponent++;
-        rmantissa &= ~(1 << mantissaBits_);
+        rmantissa &= ~(1LL << mantissaBits_);
       }
-      compressedValue = ((1 << mantissaBits_) | rmantissa) << (rexponent - 1);
+      compressedValue = ((1LL << mantissaBits_) | rmantissa) << (rexponent - 1);
     }
   }
   compressedValue <<= truncationBits_;
 }
 
 void HGCalVFECompressionImpl::compress(const std::unordered_map<uint32_t, uint32_t>& payload,
-                                       std::unordered_map<uint32_t, std::array<uint32_t, 2> >& compressed_payload) {
+                                       std::unordered_map<uint32_t, std::array<uint64_t, 2> >& compressed_payload) {
   for (const auto& item : payload) {
-    const uint32_t value = item.second;
+    const uint64_t value = static_cast<uint64_t>(item.second);
     uint32_t code(0);
-    uint32_t compressed_value(0);
+    uint64_t compressed_value(0);
     compressSingle(value, code, compressed_value);
-    std::array<uint32_t, 2> compressed_item = {{code, compressed_value}};
+    std::array<uint64_t, 2> compressed_item = {{static_cast<uint64_t>(code), compressed_value}};
     compressed_payload.emplace(item.first, compressed_item);
   }
 }

--- a/L1Trigger/L1THGCal/src/HGCalVFECompressionImpl.cc
+++ b/L1Trigger/L1THGCal/src/HGCalVFECompressionImpl.cc
@@ -13,7 +13,7 @@ HGCalVFECompressionImpl::HGCalVFECompressionImpl(const edm::ParameterSet& conf)
   saturationCode_ = (1 << (exponentBits_ + mantissaBits_)) - 1;
   saturationValue_ = (exponentBits_ == 0)
                          ? saturationCode_
-                         : ((1LL << (mantissaBits_ + truncationBits_ + 1)) - 1) << ((1 << exponentBits_) - 2);
+                         : ((1ULL << (mantissaBits_ + truncationBits_ + 1)) - 1) << ((1 << exponentBits_) - 2);
 }
 
 void HGCalVFECompressionImpl::compressSingle(const uint64_t value,
@@ -40,7 +40,7 @@ void HGCalVFECompressionImpl::compressSingle(const uint64_t value,
 
   // build exponent and mantissa
   const uint32_t exponent = bitlen - mantissaBits_;
-  const uint64_t mantissa = (shifted_value >> (exponent - 1)) & ~(1LL << mantissaBits_);
+  const uint64_t mantissa = (shifted_value >> (exponent - 1)) & ~(1ULL << mantissaBits_);
 
   // assemble floating-point
   const uint32_t floatval = (exponent << mantissaBits_) | mantissa;
@@ -48,21 +48,21 @@ void HGCalVFECompressionImpl::compressSingle(const uint64_t value,
   // we will never want to round up maximum code here
   if (!rounding_ || floatval == saturationCode_) {
     compressedCode = floatval;
-    compressedValue = ((1LL << mantissaBits_) | mantissa) << (exponent - 1);
+    compressedValue = ((1ULL << mantissaBits_) | mantissa) << (exponent - 1);
   } else {
-    const bool roundup = ((shifted_value >> (exponent - 2)) & 1LL) == 1LL;
+    const bool roundup = ((shifted_value >> (exponent - 2)) & 1ULL) == 1ULL;
     if (!roundup) {
       compressedCode = floatval;
-      compressedValue = ((1LL << mantissaBits_) | mantissa) << (exponent - 1);
+      compressedValue = ((1ULL << mantissaBits_) | mantissa) << (exponent - 1);
     } else {
       compressedCode = floatval + 1;
       uint64_t rmantissa = mantissa + 1;
       uint32_t rexponent = exponent;
       if (rmantissa >= (1ULL << mantissaBits_)) {
         rexponent++;
-        rmantissa &= ~(1LL << mantissaBits_);
+        rmantissa &= ~(1ULL << mantissaBits_);
       }
-      compressedValue = ((1LL << mantissaBits_) | rmantissa) << (rexponent - 1);
+      compressedValue = ((1ULL << mantissaBits_) | rmantissa) << (rexponent - 1);
     }
   }
   compressedValue <<= truncationBits_;

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -26,8 +26,9 @@ void HGCalConcentratorCoarsenerImpl::assignCoarseTriggerCellEnergy(l1t::HGCalTri
   uint64_t compressed_value(0);
   vfeCompression_.compressSingle(ctc.sumHwPt, code, compressed_value);
 
-  if (compressed_value > 0xFFFFFFFF)
+  if (compressed_value > std::numeric_limits<int>::max())
     edm::LogWarning("CompressedValueDowncasting") << "Compressed value cannot fit into 32-bit word. Downcasting.";
+
   tc.setHwPt(static_cast<int>(compressed_value));
   calibration_.calibrateInGeV(tc);
 }

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -23,10 +23,10 @@ void HGCalConcentratorCoarsenerImpl::assignCoarseTriggerCellEnergy(l1t::HGCalTri
                                                                    const CoarseTC& ctc) const {
   //Compress and recalibrate CTC energy
   uint32_t code(0);
-  uint32_t compressed_value(0);
+  uint64_t compressed_value(0);
   vfeCompression_.compressSingle(ctc.sumHwPt, code, compressed_value);
 
-  tc.setHwPt(compressed_value);
+  tc.setHwPt(static_cast<int>(compressed_value));
   calibration_.calibrateInGeV(tc);
 }
 

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorCoarsenerImpl.cc
@@ -26,6 +26,8 @@ void HGCalConcentratorCoarsenerImpl::assignCoarseTriggerCellEnergy(l1t::HGCalTri
   uint64_t compressed_value(0);
   vfeCompression_.compressSingle(ctc.sumHwPt, code, compressed_value);
 
+  if (compressed_value > 0xFFFFFFFF)
+    edm::LogWarning("CompressedValueDowncasting") << "Compressed value cannot fit into 32-bit word. Downcasting.";
   tc.setHwPt(static_cast<int>(compressed_value));
   calibration_.calibrateInGeV(tc);
 }

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -33,8 +33,10 @@ uint32_t HGCalConcentratorSuperTriggerCellImpl::getCompressedSTCEnergy(const Sup
   uint32_t code(0);
   uint64_t compressed_value(0);
   vfeCompression_.compressSingle(stc.getSumHwPt(), code, compressed_value);
-  if (compressed_value > 0xFFFFFFFF)
+
+  if (compressed_value > std::numeric_limits<uint32_t>::max())
     edm::LogWarning("CompressedValueDowncasting") << "Compressed value cannot fit into 32-bit word. Downcasting.";
+
   return static_cast<uint32_t>(compressed_value);
 }
 

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -31,9 +31,9 @@ HGCalConcentratorSuperTriggerCellImpl::HGCalConcentratorSuperTriggerCellImpl(con
 
 uint32_t HGCalConcentratorSuperTriggerCellImpl::getCompressedSTCEnergy(const SuperTriggerCell& stc) const {
   uint32_t code(0);
-  uint32_t compressed_value(0);
+  uint64_t compressed_value(0);
   vfeCompression_.compressSingle(stc.getSumHwPt(), code, compressed_value);
-  return compressed_value;
+  return static_cast<uint32_t>(compressed_value);
 }
 
 void HGCalConcentratorSuperTriggerCellImpl::createAllTriggerCells(

--- a/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
+++ b/L1Trigger/L1THGCal/src/concentrator/HGCalConcentratorSuperTriggerCellImpl.cc
@@ -33,6 +33,8 @@ uint32_t HGCalConcentratorSuperTriggerCellImpl::getCompressedSTCEnergy(const Sup
   uint32_t code(0);
   uint64_t compressed_value(0);
   vfeCompression_.compressSingle(stc.getSumHwPt(), code, compressed_value);
+  if (compressed_value > 0xFFFFFFFF)
+    edm::LogWarning("CompressedValueDowncasting") << "Compressed value cannot fit into 32-bit word. Downcasting.";
   return static_cast<uint32_t>(compressed_value);
 }
 


### PR DESCRIPTION
Made some changes in floating point compression algorithm, to work in 64-bit, to support 5E/3M format which will be used to store trigger sums.

This is untested for now. It is hoped that this PR can facilitate testing.