### PR TITLE
HGCalTriggerGeometryBase: stage1_to_lpgbts_ now a map of vectors of lpgbtIDs

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -60,7 +60,7 @@ public:
   virtual unsigned getStage1FpgaFromStage1Link(const unsigned) const = 0;
   virtual unsigned getStage2FpgaFromStage1Link(const unsigned) const = 0;
   virtual geom_set getStage1LinksFromStage1Fpga(const unsigned) const = 0;
-  virtual geom_set getLpgbtsFromStage1Fpga(const unsigned stage1_id) const = 0;
+  virtual std::vector<unsigned> getLpgbtsFromStage1Fpga(const unsigned stage1_id) const = 0;
   virtual unsigned getStage1FpgaFromLpgbt(const unsigned lpgbt_id) const = 0;
   virtual geom_set getModulesFromLpgbt(const unsigned lpgbt_id) const = 0;
   virtual geom_set getLpgbtsFromModule(const unsigned module_id) const = 0;

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
@@ -42,7 +42,7 @@ public:
   unsigned getStage1FpgaFromStage1Link(const unsigned) const final;
   unsigned getStage2FpgaFromStage1Link(const unsigned) const final;
   geom_set getStage1LinksFromStage1Fpga(const unsigned) const final;
-  geom_set getLpgbtsFromStage1Fpga(const unsigned) const final;
+  std::vector<unsigned> getLpgbtsFromStage1Fpga(const unsigned) const final;
   unsigned getStage1FpgaFromLpgbt(const unsigned) const final;
   geom_set getModulesFromLpgbt(const unsigned) const final;
   geom_set getLpgbtsFromModule(const unsigned) const final;
@@ -863,8 +863,8 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getStage1LinksFro
   return stage1link_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getLpgbtsFromStage1Fpga(const unsigned) const {
-  geom_set lpgbt_ids;
+std::vector<unsigned> HGCalTriggerGeometryV9Imp2::getLpgbtsFromStage1Fpga(const unsigned) const {
+  std::vector<unsigned> lpgbt_ids;
   return lpgbt_ids;
 }
 

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -658,11 +658,11 @@ std::vector<unsigned> HGCalTriggerGeometryV9Imp3::getLpgbtsFromStage1Fpga(const 
   std::vector<unsigned> lpgbt_ids;
   HGCalTriggerBackendDetId id(stage1_id);
 
-  auto stage1_itrs = stage1_to_lpgbts_.at(id.label());
-  lpgbt_ids.reserve(stage1_itrs.size());
-  for (auto stage1_itr : stage1_itrs) {
-    lpgbt_ids.push_back(
-        HGCalTriggerBackendDetId(id.zside(), HGCalTriggerBackendDetId::BackendType::LpGBT, id.sector(), stage1_itr));
+  const auto stage1_lpgbts = stage1_to_lpgbts_.at(id.label());
+  lpgbt_ids.reserve(stage1_lpgbts.size());
+  for (const auto& stage1_lpgbt : stage1_lpgbts) {
+    lpgbt_ids.emplace_back(
+        HGCalTriggerBackendDetId(id.zside(), HGCalTriggerBackendDetId::BackendType::LpGBT, id.sector(), stage1_lpgbt));
   }
 
   return lpgbt_ids;

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -88,7 +88,7 @@ private:
   std::unordered_map<unsigned, unsigned> stage1link_to_stage2_;
   std::unordered_map<unsigned, unsigned> stage1link_to_stage1_;
   std::unordered_multimap<unsigned, unsigned> stage1_to_stage1links_;
-  std::unordered_map<unsigned, std::vector<unsigned> > stage1_to_lpgbts_;
+  std::unordered_map<unsigned, std::vector<unsigned>> stage1_to_lpgbts_;
   std::unordered_map<unsigned, unsigned> lpgbt_to_stage1_;
   std::unordered_multimap<unsigned, unsigned> lpgbt_to_modules_;
   std::unordered_multimap<unsigned, unsigned> module_to_lpgbts_;
@@ -659,9 +659,10 @@ std::vector<unsigned> HGCalTriggerGeometryV9Imp3::getLpgbtsFromStage1Fpga(const 
   HGCalTriggerBackendDetId id(stage1_id);
 
   auto stage1_itrs = stage1_to_lpgbts_.at(id.label());
+  lpgbt_ids.reserve(stage1_itrs.size());
   for (auto stage1_itr : stage1_itrs) {
-    lpgbt_ids.push_back(HGCalTriggerBackendDetId(
-        id.zside(), HGCalTriggerBackendDetId::BackendType::LpGBT, id.sector(), stage1_itr));
+    lpgbt_ids.push_back(
+        HGCalTriggerBackendDetId(id.zside(), HGCalTriggerBackendDetId::BackendType::LpGBT, id.sector(), stage1_itr));
   }
 
   return lpgbt_ids;

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -45,7 +45,7 @@ public:
   unsigned getStage1FpgaFromStage1Link(const unsigned) const final;
   unsigned getStage2FpgaFromStage1Link(const unsigned) const final;
   geom_set getStage1LinksFromStage1Fpga(const unsigned) const final;
-  geom_set getLpgbtsFromStage1Fpga(const unsigned) const final;
+  std::vector<unsigned> getLpgbtsFromStage1Fpga(const unsigned) const final;
   unsigned getStage1FpgaFromLpgbt(const unsigned) const final;
   geom_set getModulesFromLpgbt(const unsigned) const final;
   geom_set getLpgbtsFromModule(const unsigned) const final;
@@ -88,7 +88,7 @@ private:
   std::unordered_map<unsigned, unsigned> stage1link_to_stage2_;
   std::unordered_map<unsigned, unsigned> stage1link_to_stage1_;
   std::unordered_multimap<unsigned, unsigned> stage1_to_stage1links_;
-  std::unordered_multimap<unsigned, unsigned> stage1_to_lpgbts_;
+  std::unordered_map<unsigned, std::vector<unsigned> > stage1_to_lpgbts_;
   std::unordered_map<unsigned, unsigned> lpgbt_to_stage1_;
   std::unordered_multimap<unsigned, unsigned> lpgbt_to_modules_;
   std::unordered_multimap<unsigned, unsigned> module_to_lpgbts_;
@@ -654,14 +654,14 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage1LinksFro
   return stage1link_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getLpgbtsFromStage1Fpga(const unsigned stage1_id) const {
-  geom_set lpgbt_ids;
+std::vector<unsigned> HGCalTriggerGeometryV9Imp3::getLpgbtsFromStage1Fpga(const unsigned stage1_id) const {
+  std::vector<unsigned> lpgbt_ids;
   HGCalTriggerBackendDetId id(stage1_id);
 
-  auto stage1_itrs = stage1_to_lpgbts_.equal_range(id.label());
-  for (auto stage1_itr = stage1_itrs.first; stage1_itr != stage1_itrs.second; stage1_itr++) {
-    lpgbt_ids.emplace(HGCalTriggerBackendDetId(
-        id.zside(), HGCalTriggerBackendDetId::BackendType::LpGBT, id.sector(), stage1_itr->second));
+  auto stage1_itrs = stage1_to_lpgbts_.at(id.label());
+  for (auto stage1_itr : stage1_itrs) {
+    lpgbt_ids.push_back(HGCalTriggerBackendDetId(
+        id.zside(), HGCalTriggerBackendDetId::BackendType::LpGBT, id.sector(), stage1_itr));
   }
 
   return lpgbt_ids;
@@ -841,9 +841,11 @@ void HGCalTriggerGeometryV9Imp3::fillMaps() {
       }
 
       //Stage 1 to lpgbt mapping
+      std::vector<unsigned> lpgbt_id_vec;
       for (auto& lpgbt_id : mapping_config.at("Stage1").at(stage1_id).at("lpgbts")) {
-        stage1_to_lpgbts_.emplace(stage1_id, lpgbt_id);
+        lpgbt_id_vec.push_back(lpgbt_id);
       }
+      stage1_to_lpgbts_.emplace(stage1_id, lpgbt_id_vec);
     }
 
   } catch (const json::exception& e) {

--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
@@ -713,7 +713,7 @@ bool HGCalTriggerGeomTesterV9Imp3::checkMappingConsistency() {
       HGCalTriggerBackendDetId stage1(stage1_modules.first);
       HGCalTriggerGeometryBase::geom_set modules_geom;
       // Check consistency of modules going to Stage-1 FPGA
-      HGCalTriggerGeometryBase::geom_set lpgbts = triggerGeometry_->getLpgbtsFromStage1Fpga(stage1);
+      std::vector<unsigned> lpgbts = triggerGeometry_->getLpgbtsFromStage1Fpga(stage1);
       for (const auto& lpgbt : lpgbts) {
         HGCalTriggerGeometryBase::geom_set modules = triggerGeometry_->getModulesFromLpgbt(lpgbt);
         modules_geom.insert(modules.begin(), modules.end());


### PR DESCRIPTION
#### PR description:

`stage1_to_lpgbts_` is now a map of vectors of lpgbtIDs. The purpose of this is to preserve the ordering of the lpgbtIDs upon calling `getLpgbtsFromStage1Fpga`, so that test pattern writer can write the test pattern with the correct ordering of lpgbts.

#### PR validation:

No widespread testing yet for the whole CMSSW, apart from my development code on stage 1 test pattern writer in which it works as expected.

