### PR TITLE
add orientation and partials' type for each wafer

### DIFF
--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
@@ -122,6 +122,8 @@ private:
   int triggerCellLayer_ = 0;
   int triggerCellWaferU_ = 0;
   int triggerCellWaferV_ = 0;
+  int triggerCellWaferPart_ = -1;
+  int triggerCellWaferOrient_ = -1;
   int triggerCellU_ = 0;
   int triggerCellV_ = 0;
   int triggerCellIEta_ = 0;
@@ -300,6 +302,8 @@ HGCalTriggerGeomTesterV9Imp3::HGCalTriggerGeomTesterV9Imp3(const edm::ParameterS
   treeTriggerCells_->Branch("layer", &triggerCellLayer_, "layer/I");
   treeTriggerCells_->Branch("waferu", &triggerCellWaferU_, "waferu/I");
   treeTriggerCells_->Branch("waferv", &triggerCellWaferV_, "waferv/I");
+  treeTriggerCells_->Branch("waferpart", &triggerCellWaferPart_, "waferpart/I");
+  treeTriggerCells_->Branch("waferorient", &triggerCellWaferOrient_, "waferorient/I");
   treeTriggerCells_->Branch("triggercellu", &triggerCellU_, "triggercellu/I");
   treeTriggerCells_->Branch("triggercellv", &triggerCellV_, "triggercellv/I");
   treeTriggerCells_->Branch("triggercellieta", &triggerCellIEta_, "triggercellieta/I");
@@ -978,6 +982,7 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
   edm::LogPrint("TreeFilling") << "Filling trigger cells tree";
   for (const auto& triggercell_cells : trigger_cells) {
     DetId id(triggercell_cells.first);
+    std::tuple<int, int, int> wafertype;
     GlobalPoint position = triggerGeometry_->getTriggerCellPosition(triggercell_cells.first);
     triggerCellId_ = id.rawId();
     if (id.det() == DetId::HGCalHSc) {
@@ -989,6 +994,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
       triggerCellIPhi_ = id_sc.iphi();
       triggerCellWaferU_ = 0;
       triggerCellWaferV_ = 0;
+	  triggerCellWaferPart_ = -1;
+	  triggerCellWaferOrient_ = -1;
       triggerCellU_ = 0;
       triggerCellV_ = 0;
     } else if (HFNoseTriggerDetId(triggercell_cells.first).det() == DetId::HGCalTrigger &&
@@ -1001,6 +1008,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
       triggerCellIPhi_ = 0;
       triggerCellWaferU_ = id_nose_trig.waferU();
       triggerCellWaferV_ = id_nose_trig.waferV();
+	  triggerCellWaferPart_ = -1;
+	  triggerCellWaferOrient_ = -1;
       triggerCellU_ = id_nose_trig.triggerCellU();
       triggerCellV_ = id_nose_trig.triggerCellV();
     } else {
@@ -1014,7 +1023,25 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
       triggerCellWaferV_ = id_si_trig.waferV();
       triggerCellU_ = id_si_trig.triggerCellU();
       triggerCellV_ = id_si_trig.triggerCellV();
-    }
+
+	  if(triggercell_cells.second.begin() == triggercell_cells.second.end()) {
+		throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: No cells!";
+	  }
+	  const HGCSiliconDetId& firstCellId(*triggercell_cells.second.begin());
+	  if(firstCellId.det() == DetId::HGCalEE) {
+		wafertype = triggerGeometry_->eeTopology().dddConstants().waferType(firstCellId, true);
+	  }
+	  else if(firstCellId.det() == DetId::HGCalHSi) {
+		wafertype = triggerGeometry_->hsiTopology().dddConstants().waferType(firstCellId, true);
+	  }
+	  else {
+		throw cms::Exception("BadGeometry")
+              << "HGCalTriggerGeometry: Found inconsistency in cell <-> trigger cell type mapping";
+	  }
+	  triggerCellWaferPart_ = std::get<1>(wafertype);
+	  triggerCellWaferOrient_ = std::get<2>(wafertype);
+	  
+	}
     triggerCellX_ = position.x();
     triggerCellY_ = position.y();
     triggerCellZ_ = position.z();

--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
@@ -994,8 +994,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
       triggerCellIPhi_ = id_sc.iphi();
       triggerCellWaferU_ = 0;
       triggerCellWaferV_ = 0;
-	  triggerCellWaferPart_ = -1;
-	  triggerCellWaferOrient_ = -1;
+      triggerCellWaferPart_ = -1;
+      triggerCellWaferOrient_ = -1;
       triggerCellU_ = 0;
       triggerCellV_ = 0;
     } else if (HFNoseTriggerDetId(triggercell_cells.first).det() == DetId::HGCalTrigger &&
@@ -1008,8 +1008,8 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
       triggerCellIPhi_ = 0;
       triggerCellWaferU_ = id_nose_trig.waferU();
       triggerCellWaferV_ = id_nose_trig.waferV();
-	  triggerCellWaferPart_ = -1;
-	  triggerCellWaferOrient_ = -1;
+      triggerCellWaferPart_ = -1;
+      triggerCellWaferOrient_ = -1;
       triggerCellU_ = id_nose_trig.triggerCellU();
       triggerCellV_ = id_nose_trig.triggerCellV();
     } else {
@@ -1024,24 +1024,21 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
       triggerCellU_ = id_si_trig.triggerCellU();
       triggerCellV_ = id_si_trig.triggerCellV();
 
-	  if(triggercell_cells.second.begin() == triggercell_cells.second.end()) {
-		throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: No cells!";
-	  }
-	  const HGCSiliconDetId& firstCellId(*triggercell_cells.second.begin());
-	  if(firstCellId.det() == DetId::HGCalEE) {
-		wafertype = triggerGeometry_->eeTopology().dddConstants().waferType(firstCellId, true);
-	  }
-	  else if(firstCellId.det() == DetId::HGCalHSi) {
-		wafertype = triggerGeometry_->hsiTopology().dddConstants().waferType(firstCellId, true);
-	  }
-	  else {
-		throw cms::Exception("BadGeometry")
-              << "HGCalTriggerGeometry: Found inconsistency in cell <-> trigger cell type mapping";
-	  }
-	  triggerCellWaferPart_ = std::get<1>(wafertype);
-	  triggerCellWaferOrient_ = std::get<2>(wafertype);
-	  
-	}
+      if (triggercell_cells.second.begin() == triggercell_cells.second.end()) {
+        throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: No cells!";
+      }
+      const HGCSiliconDetId& firstCellId(*triggercell_cells.second.begin());
+      if (firstCellId.det() == DetId::HGCalEE) {
+        wafertype = triggerGeometry_->eeTopology().dddConstants().waferType(firstCellId, true);
+      } else if (firstCellId.det() == DetId::HGCalHSi) {
+        wafertype = triggerGeometry_->hsiTopology().dddConstants().waferType(firstCellId, true);
+      } else {
+        throw cms::Exception("BadGeometry")
+            << "HGCalTriggerGeometry: Found inconsistency in cell <-> trigger cell type mapping";
+      }
+      triggerCellWaferPart_ = std::get<1>(wafertype);
+      triggerCellWaferOrient_ = std::get<2>(wafertype);
+    }
     triggerCellX_ = position.x();
     triggerCellY_ = position.y();
     triggerCellZ_ = position.z();

--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
@@ -981,6 +981,10 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
   // Loop over trigger cells
   edm::LogPrint("TreeFilling") << "Filling trigger cells tree";
   for (const auto& triggercell_cells : trigger_cells) {
+    if (!triggercell_cells.second.size()) {
+      throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: No cells in trigger cell!";
+    }
+
     DetId id(triggercell_cells.first);
     std::tuple<int, int, int> wafertype;
     GlobalPoint position = triggerGeometry_->getTriggerCellPosition(triggercell_cells.first);
@@ -1024,14 +1028,11 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
       triggerCellU_ = id_si_trig.triggerCellU();
       triggerCellV_ = id_si_trig.triggerCellV();
 
-      if (triggercell_cells.second.begin() == triggercell_cells.second.end()) {
-        throw cms::Exception("BadGeometry") << "HGCalTriggerGeometry: No cells!";
-      }
       const HGCSiliconDetId& firstCellId(*triggercell_cells.second.begin());
       if (firstCellId.det() == DetId::HGCalEE) {
-        wafertype = triggerGeometry_->eeTopology().dddConstants().waferType(firstCellId, true);
+        wafertype = triggerGeometry_->eeTopology().dddConstants().waferType(firstCellId, false);
       } else if (firstCellId.det() == DetId::HGCalHSi) {
-        wafertype = triggerGeometry_->hsiTopology().dddConstants().waferType(firstCellId, true);
+        wafertype = triggerGeometry_->hsiTopology().dddConstants().waferType(firstCellId, false);
       } else {
         throw cms::Exception("BadGeometry")
             << "HGCalTriggerGeometry: Found inconsistency in cell <-> trigger cell type mapping";

--- a/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
+++ b/L1Trigger/L1THGCal/test/HGCalTriggerGeomTesterV9Imp3.cc
@@ -1030,9 +1030,9 @@ void HGCalTriggerGeomTesterV9Imp3::fillTriggerGeometry()
 
       const HGCSiliconDetId& firstCellId(*triggercell_cells.second.begin());
       if (firstCellId.det() == DetId::HGCalEE) {
-        wafertype = triggerGeometry_->eeTopology().dddConstants().waferType(firstCellId, false);
+        wafertype = triggerGeometry_->eeTopology().dddConstants().waferType(firstCellId);
       } else if (firstCellId.det() == DetId::HGCalHSi) {
-        wafertype = triggerGeometry_->hsiTopology().dddConstants().waferType(firstCellId, false);
+        wafertype = triggerGeometry_->hsiTopology().dddConstants().waferType(firstCellId);
       } else {
         throw cms::Exception("BadGeometry")
             << "HGCalTriggerGeometry: Found inconsistency in cell <-> trigger cell type mapping";


### PR DESCRIPTION
Include wafers' orientation (6 possible values, equal to the number of sides of a hexagon) and type of partials (full, five, three, ...) in the trigger cell geometry information. Required for drawing the geometry with the correct orientation. 

After the modification, ```cmsRun L1Trigger/L1THGCal/test/testHGCalL1TGeometryV11Imp3_cfg.py``` runs successfully, producing the geometry ```test_triggergeom.root``` file (458MB).

The default dummy value is -1 for both quantities. A quick inspection of the output shows some trigger cells which have those dummy values. They seem to correspond to wafers in the central hole (most results have U=0 and V=0), and the remaining ones are likely wafers outside the outer boundary.

<img src="https://user-images.githubusercontent.com/20703947/209376644-e72b46b4-696a-40d2-b16d-3772d6c1e4d3.png" width="250" height="250" /> <img src="https://user-images.githubusercontent.com/20703947/209376643-e23d3ea3-9ed4-4c49-83df-667b5190569e.png" width="250" height="250" />  <img src="https://user-images.githubusercontent.com/20703947/209376646-675f34fc-45b6-482a-a082-99f48fd0e606.png" width="250" height="250" />

