### PR TITLE
Fix 2D cluster collection produced with Stage 1 emulator

### DIFF
--- a/L1Trigger/L1THGCal/src/backend/HGCalClusteringDummyImpl.cc
+++ b/L1Trigger/L1THGCal/src/backend/HGCalClusteringDummyImpl.cc
@@ -23,10 +23,9 @@ void HGCalClusteringDummyImpl::clusterizeDummy(const std::vector<edm::Ptr<l1t::H
   }
 
   /* store clusters in the persistent collection */
-  clusters.resize(0, clustersTmp.size());
-  for (unsigned i(0); i < clustersTmp.size(); ++i) {
-    calibratePt(clustersTmp.at(i));
-    clusters.set(0, i, clustersTmp.at(i));
+  for (auto& cluster : clustersTmp) {
+    calibratePt(cluster);
+    clusters.push_back(0, cluster);
   }
 }
 

--- a/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
+++ b/L1Trigger/L1THGCalUtilities/python/hgcalTriggerNtuples_cfi.py
@@ -111,6 +111,7 @@ l1tHGCalTriggerNtuplizer = cms.EDAnalyzer(
         ntuple_digis,
         ntuple_triggercells,
         ntuple_triggersums,
+        ntuple_clusters,
         ntuple_multiclusters,
         ntuple_towers
     )


### PR DESCRIPTION
The output 2D cluster collection was re-initialized for each processor call, so that the final collection of 2D clusters produced by the Stage 1 emulator was containing just the objects corresponding to one single Stage 1 FPGA region.

This PR removes the re-initialization and instead append new clusters to the existing collection, so that the collection grows after each processor call.  

Should fix #107 