### PR TITLE
Geometry tester refactoring

### DIFF
--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeoTesterBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeoTesterBase.h
@@ -1,0 +1,75 @@
+#ifndef __L1Trigger_L1THGCal_HGCalTriggerGeoTesterBase_h__
+#define __L1Trigger_L1THGCal_HGCalTriggerGeoTesterBase_h__
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "TTree.h"
+#include <unordered_map>
+#include <string>
+
+namespace HepPDT {
+  class ParticleDataTable;
+}
+class MagneticField;
+class HGCalTriggerGeometryBase;
+
+struct HGCalTriggerGeoTesterEventSetup {
+  edm::ESHandle<HGCalTriggerGeometryBase> geometry;
+};
+
+class HGCalTriggerGeoTesterErrors {
+public:
+  enum ErrorCode {
+    CellValidity = 0,
+    MissingCellInTC,
+    InvalidCellInTC,
+    MissingTCInModule,
+    InvalidTCInModule,
+    ConnectedModuleWithoutLpgbt,
+    ModuleSplitInStage1,
+    MissingModuleInStage1FPGA,
+    InvalidModuleInStage1FPGA,
+    MissingStage1InStage2FPGA,
+    InvalidStage1InStage2FPGA
+  };
+  static const std::unordered_map<ErrorCode, std::string> messages;
+
+  void fill(ErrorCode error, unsigned detid) {
+    auto itr_err = error_detids_.insert({error, {}}).first;
+    itr_err->second.insert(detid);
+    auto itr_id = detid_errors_.insert({detid, {}}).first;
+    itr_id->second.insert(error);
+  }
+  const std::unordered_map<ErrorCode, std::set<unsigned>>& errors() const { return error_detids_; }
+  const std::unordered_map<unsigned, std::set<ErrorCode>>& detids() const { return detid_errors_; }
+
+private:
+  std::unordered_map<ErrorCode, std::set<unsigned>> error_detids_;
+  std::unordered_map<unsigned, std::set<ErrorCode>> detid_errors_;
+};
+
+class HGCalTriggerGeoTesterBase {
+public:
+  HGCalTriggerGeoTesterBase(const edm::ParameterSet& conf) : name_(conf.getParameter<std::string>("TesterName")){};
+  virtual ~HGCalTriggerGeoTesterBase(){};
+  const std::string& name() const { return name_; }
+  virtual void initialize(TTree*, const edm::ParameterSet&) = 0;
+  virtual void check(const HGCalTriggerGeoTesterEventSetup&) = 0;
+  virtual void fill(const HGCalTriggerGeoTesterEventSetup&) = 0;
+  const HGCalTriggerGeoTesterErrors& errors() { return errors_; }
+
+protected:
+  virtual void clear() = 0;
+  const std::string name_;
+  HGCalTriggerGeoTesterErrors errors_;
+  TTree* tree_;
+};
+
+#include "FWCore/PluginManager/interface/PluginFactory.h"
+typedef edmplugin::PluginFactory<HGCalTriggerGeoTesterBase*(const edm::ParameterSet&)> HGCalTriggerGeoTesterFactory;
+
+#endif

--- a/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
+++ b/L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h
@@ -61,6 +61,7 @@ public:
   virtual unsigned getStage2FpgaFromStage1Link(const unsigned) const = 0;
   virtual geom_set getStage1LinksFromStage1Fpga(const unsigned) const = 0;
   virtual std::vector<unsigned> getLpgbtsFromStage1Fpga(const unsigned stage1_id) const = 0;
+  virtual geom_set getModulesFromStage1Fpga(const unsigned stage1_id) const = 0;
   virtual unsigned getStage1FpgaFromLpgbt(const unsigned lpgbt_id) const = 0;
   virtual geom_set getModulesFromLpgbt(const unsigned lpgbt_id) const = 0;
   virtual geom_set getLpgbtsFromModule(const unsigned module_id) const = 0;

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp2.cc
@@ -43,6 +43,7 @@ public:
   unsigned getStage2FpgaFromStage1Link(const unsigned) const final;
   geom_set getStage1LinksFromStage1Fpga(const unsigned) const final;
   std::vector<unsigned> getLpgbtsFromStage1Fpga(const unsigned) const final;
+  geom_set getModulesFromStage1Fpga(const unsigned) const final;
   unsigned getStage1FpgaFromLpgbt(const unsigned) const final;
   geom_set getModulesFromLpgbt(const unsigned) const final;
   geom_set getLpgbtsFromModule(const unsigned) const final;
@@ -867,6 +868,11 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getStage1LinksFro
 std::vector<unsigned> HGCalTriggerGeometryV9Imp2::getLpgbtsFromStage1Fpga(const unsigned) const {
   std::vector<unsigned> lpgbt_ids;
   return lpgbt_ids;
+}
+
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp2::getModulesFromStage1Fpga(const unsigned) const {
+  geom_set modules;
+  return modules;
 }
 
 unsigned HGCalTriggerGeometryV9Imp2::getStage1FpgaFromLpgbt(const unsigned) const {

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -46,6 +46,7 @@ public:
   unsigned getStage2FpgaFromStage1Link(const unsigned) const final;
   geom_set getStage1LinksFromStage1Fpga(const unsigned) const final;
   std::vector<unsigned> getLpgbtsFromStage1Fpga(const unsigned) const final;
+  geom_set getModulesFromStage1Fpga(const unsigned) const final;
   unsigned getStage1FpgaFromLpgbt(const unsigned) const final;
   geom_set getModulesFromLpgbt(const unsigned) const final;
   geom_set getLpgbtsFromModule(const unsigned) const final;
@@ -671,6 +672,14 @@ std::vector<unsigned> HGCalTriggerGeometryV9Imp3::getLpgbtsFromStage1Fpga(const 
   return lpgbt_ids;
 }
 
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getModulesFromStage1Fpga(const unsigned stage1_id) const {
+  auto lpgbts = getLpgbtsFromStage1Fpga(stage1_id);
+  geom_set modules;
+  for (auto lpgbt : lpgbts) {
+    modules.merge(getModulesFromLpgbt(lpgbt));
+  }
+  return modules;
+}
 unsigned HGCalTriggerGeometryV9Imp3::getStage1FpgaFromLpgbt(const unsigned lpgbt_id) const {
   HGCalTriggerBackendDetId id(lpgbt_id);
   unsigned stage1_label = lpgbt_to_stage1_.at(id.label());

--- a/L1Trigger/L1THGCal/src/HGCalTriggerGeoTesterBase.cc
+++ b/L1Trigger/L1THGCal/src/HGCalTriggerGeoTesterBase.cc
@@ -1,0 +1,16 @@
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeoTesterBase.h"
+
+const std::unordered_map<HGCalTriggerGeoTesterErrors::ErrorCode, std::string> HGCalTriggerGeoTesterErrors::messages = {
+    {HGCalTriggerGeoTesterErrors::CellValidity, "Found invalid cell(s)"},
+    {HGCalTriggerGeoTesterErrors::MissingCellInTC, "Found missing cell(s) in trigger cell"},
+    {HGCalTriggerGeoTesterErrors::InvalidCellInTC, "Found invalid cell(s) in trigger cell"},
+    {HGCalTriggerGeoTesterErrors::MissingTCInModule, "Found missing trigger cell(s) in module"},
+    {HGCalTriggerGeoTesterErrors::InvalidTCInModule, "Found invalid trigger cell(s) in module"},
+    {HGCalTriggerGeoTesterErrors::ConnectedModuleWithoutLpgbt, "Found module without lpGBT but flagged as connected"},
+    {HGCalTriggerGeoTesterErrors::ModuleSplitInStage1, "Found module with lpGBTs connected to several Stage 1 FPGAs"},
+    {HGCalTriggerGeoTesterErrors::MissingModuleInStage1FPGA, "Found missing module(s) in Stage 1 FPGA"},
+    {HGCalTriggerGeoTesterErrors::InvalidModuleInStage1FPGA, "Found invalid module(s) in Stage 1 FPGA"},
+    {HGCalTriggerGeoTesterErrors::MissingStage1InStage2FPGA, "Found missing stage1(s) in Stage 2 FPGA"},
+    {HGCalTriggerGeoTesterErrors::InvalidStage1InStage2FPGA, "Found invalid stage1(s) in Stage 2 FPGA"}};
+
+EDM_REGISTER_PLUGINFACTORY(HGCalTriggerGeoTesterFactory, "HGCalTriggerGeoTesterFactory");

--- a/L1Trigger/L1THGCal/test/BuildFile.xml
+++ b/L1Trigger/L1THGCal/test/BuildFile.xml
@@ -1,7 +1,15 @@
-<use name="Geometry/HGCalGeometry"/>
-<use name="L1Trigger/L1THGCal"/>
-<use name="Geometry/Records"/>
-<use name="CommonTools/UtilAlgos"/>
 <library name="testL1TriggerL1THGCal" file="HGCalTriggerGeomTesterV9Imp2.cc,HGCalTriggerGeomTesterV9Imp3.cc,HGCalBackendStage1ParameterExtractor.cc">
+  <use name="Geometry/HGCalGeometry"/>
+  <use name="L1Trigger/L1THGCal"/>
+  <use name="Geometry/Records"/>
+  <use name="CommonTools/UtilAlgos"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
+
+<library name="testL1TriggerL1THGCal_geometry" file="geometry/*.cc">
+  <use name="Geometry/HGCalGeometry"/>
+  <use name="L1Trigger/L1THGCal"/>
+  <use name="Geometry/Records"/>
+  <use name="CommonTools/UtilAlgos"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/L1Trigger/L1THGCal/test/geometry/HGCalTriggerGeoTesterBackendStage1.cc
+++ b/L1Trigger/L1THGCal/test/geometry/HGCalTriggerGeoTesterBackendStage1.cc
@@ -1,0 +1,152 @@
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerBackendDetId.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeoTesterBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+class HGCalTriggerGeoTesterBackendStage1 : public HGCalTriggerGeoTesterBase {
+public:
+  HGCalTriggerGeoTesterBackendStage1(const edm::ParameterSet& conf);
+  ~HGCalTriggerGeoTesterBackendStage1() override{};
+  void initialize(TTree*, const edm::ParameterSet&) final;
+  void check(const HGCalTriggerGeoTesterEventSetup& es) final;
+  void fill(const HGCalTriggerGeoTesterEventSetup& es) final;
+
+private:
+  void clear() final;
+
+  HGCalTriggerTools triggerTools_;
+
+  unsigned id_ = 0;
+  unsigned errorbits_ = 0;
+  int label_ = 0;
+  int zside_ = 0;
+  int sector_ = 0;
+  int type_ = 0;
+  int lpgbts_n_ = 0;
+  int modules_n_ = 0;
+  std::vector<uint32_t> lpgbts_;
+  std::vector<uint32_t> modules_;
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerGeoTesterFactory,
+                  HGCalTriggerGeoTesterBackendStage1,
+                  "HGCalTriggerGeoTesterBackendStage1");
+
+HGCalTriggerGeoTesterBackendStage1::HGCalTriggerGeoTesterBackendStage1(const edm::ParameterSet& conf)
+    : HGCalTriggerGeoTesterBase(conf) {}
+
+void HGCalTriggerGeoTesterBackendStage1::initialize(TTree* tree, const edm::ParameterSet& conf) {
+  tree_ = tree;
+
+  tree_->Branch("id", &id_, "id/i");
+  tree_->Branch("errorbits", &errorbits_, "errorbits/i");
+  tree_->Branch("zside", &zside_, "zside/I");
+  tree_->Branch("sector", &sector_, "sector/I");
+  tree_->Branch("label", &label_, "label/I");
+  tree_->Branch("type", &type_, "type/i");
+  tree_->Branch("lpgbts_n", &lpgbts_n_, "lpgbts_n/I");
+  tree_->Branch("lpgbts", &lpgbts_);
+  tree_->Branch("modules_n", &modules_n_, "modules_n/I");
+  tree_->Branch("modules", &modules_);
+}
+
+void HGCalTriggerGeoTesterBackendStage1::fill(const HGCalTriggerGeoTesterEventSetup& es) {
+  clear();
+  edm::LogPrint("TreeFilling") << "Filling Backend Stage 1 tree";
+  // Create list of Stage 1 boards from valid cells
+  std::unordered_set<uint32_t> modules;
+  for (const auto& id : es.geometry->eeGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  for (const auto& id : es.geometry->hsiGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  for (const auto& id : es.geometry->hscGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  std::unordered_set<uint32_t> stage1s;
+  for (const auto& module : modules) {
+    if (es.geometry->disconnectedModule(module))
+      continue;
+    stage1s.insert(es.geometry->getStage1FpgaFromModule(module));
+  }
+  for (const auto& id : stage1s) {
+    HGCalTriggerBackendDetId detid(id);
+    const auto error_itr = errors_.detids().find(id);
+    if (error_itr != errors_.detids().end()) {
+      for (const auto& error : error_itr->second) {
+        errorbits_ |= (0x1 << error);
+      }
+    }
+    id_ = id;
+    zside_ = detid.zside();
+    type_ = detid.type();
+    sector_ = detid.sector();
+    label_ = detid.label();
+    auto lpgbts = es.geometry->getLpgbtsFromStage1Fpga(id);
+    lpgbts_n_ = lpgbts.size();
+    lpgbts_.resize(lpgbts.size());
+    std::copy(lpgbts.begin(), lpgbts.end(), lpgbts_.begin());
+    auto modules = es.geometry->getModulesFromStage1Fpga(id);
+    modules_n_ = modules.size();
+    modules_.resize(modules.size());
+    std::copy(modules.begin(), modules.end(), modules_.begin());
+
+    tree_->Fill();
+    clear();
+  }
+}
+
+void HGCalTriggerGeoTesterBackendStage1::check(const HGCalTriggerGeoTesterEventSetup& es) {
+  edm::LogPrint("GeoTesterBackendStage1") << "Checking Stage 1";
+  // Create list of modules from valid cells
+  std::unordered_set<uint32_t> modules;
+  for (const auto& id : es.geometry->eeGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  for (const auto& id : es.geometry->hsiGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  for (const auto& id : es.geometry->hscGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  std::unordered_map<uint32_t, std::unordered_set<uint32_t>> stage1_to_modules;
+  for (const auto& id : modules) {
+    if (es.geometry->disconnectedModule(id))
+      continue;
+    auto stage1 = es.geometry->getStage1FpgaFromModule(id);
+    auto itr_insert = stage1_to_modules.emplace(stage1, std::unordered_set<uint32_t>());
+    itr_insert.first->second.emplace(id);
+  }
+
+  // Check consistency of trigger cells included in modules
+  for (const auto& [stage1id, modules] : stage1_to_modules) {
+    HGCalTriggerGeometryBase::geom_set modules_from_stage1 = es.geometry->getModulesFromStage1Fpga(stage1id);
+    for (auto module : modules) {
+      if (modules_from_stage1.find(module) == modules_from_stage1.end()) {
+        errors_.fill(HGCalTriggerGeoTesterErrors::MissingModuleInStage1FPGA, stage1id);
+      }
+    }
+    for (auto module : modules_from_stage1) {
+      if (modules.find(module) == modules.end()) {
+        errors_.fill(HGCalTriggerGeoTesterErrors::InvalidModuleInStage1FPGA, stage1id);
+      }
+    }
+  }
+}
+
+void HGCalTriggerGeoTesterBackendStage1::clear() {
+  id_ = 0;
+  errorbits_ = 0;
+  label_ = 0;
+  zside_ = 0;
+  sector_ = 0;
+  type_ = 0;
+  lpgbts_n_ = 0;
+  lpgbts_.clear();
+  modules_n_ = 0;
+  modules_.clear();
+}

--- a/L1Trigger/L1THGCal/test/geometry/HGCalTriggerGeoTesterBackendStage2.cc
+++ b/L1Trigger/L1THGCal/test/geometry/HGCalTriggerGeoTesterBackendStage2.cc
@@ -1,0 +1,149 @@
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerBackendDetId.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeoTesterBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+class HGCalTriggerGeoTesterBackendStage2 : public HGCalTriggerGeoTesterBase {
+public:
+  HGCalTriggerGeoTesterBackendStage2(const edm::ParameterSet& conf);
+  ~HGCalTriggerGeoTesterBackendStage2() override{};
+  void initialize(TTree*, const edm::ParameterSet&) final;
+  void check(const HGCalTriggerGeoTesterEventSetup& es) final;
+  void fill(const HGCalTriggerGeoTesterEventSetup& es) final;
+
+private:
+  void clear() final;
+
+  HGCalTriggerTools triggerTools_;
+
+  unsigned id_ = 0;
+  unsigned errorbits_ = 0;
+  int label_ = 0;
+  int zside_ = 0;
+  int sector_ = 0;
+  int type_ = 0;
+  int stage1_n_ = 0;
+  std::vector<uint32_t> stage1s_;
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerGeoTesterFactory,
+                  HGCalTriggerGeoTesterBackendStage2,
+                  "HGCalTriggerGeoTesterBackendStage2");
+
+HGCalTriggerGeoTesterBackendStage2::HGCalTriggerGeoTesterBackendStage2(const edm::ParameterSet& conf)
+    : HGCalTriggerGeoTesterBase(conf) {}
+
+void HGCalTriggerGeoTesterBackendStage2::initialize(TTree* tree, const edm::ParameterSet& conf) {
+  tree_ = tree;
+
+  tree_->Branch("id", &id_, "id/i");
+  tree_->Branch("errorbits", &errorbits_, "errorbits/i");
+  tree_->Branch("zside", &zside_, "zside/I");
+  tree_->Branch("sector", &sector_, "sector/I");
+  tree_->Branch("label", &label_, "label/I");
+  tree_->Branch("type", &type_, "type/i");
+  tree_->Branch("stage1_n", &stage1_n_, "stage1_n/I");
+  tree_->Branch("stage1s", &stage1s_);
+}
+
+void HGCalTriggerGeoTesterBackendStage2::fill(const HGCalTriggerGeoTesterEventSetup& es) {
+  clear();
+  edm::LogPrint("TreeFilling") << "Filling Backend Stage 2 tree";
+  // Create list of Stage 1 boards from valid cells
+  std::unordered_set<uint32_t> modules;
+  for (const auto& id : es.geometry->eeGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  for (const auto& id : es.geometry->hsiGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  for (const auto& id : es.geometry->hscGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  std::unordered_set<uint32_t> stage2s;
+  for (const auto& module : modules) {
+    if (es.geometry->disconnectedModule(module))
+      continue;
+    auto s1 = es.geometry->getStage1FpgaFromModule(module);
+    auto s2s = es.geometry->getStage2FpgasFromStage1Fpga(s1);
+    for (auto s2 : s2s) {
+      stage2s.insert(s2);
+    }
+  }
+  for (const auto& id : stage2s) {
+    HGCalTriggerBackendDetId detid(id);
+    const auto error_itr = errors_.detids().find(id);
+    if (error_itr != errors_.detids().end()) {
+      for (const auto& error : error_itr->second) {
+        errorbits_ |= (0x1 << error);
+      }
+    }
+    id_ = id;
+    zside_ = detid.zside();
+    type_ = detid.type();
+    sector_ = detid.sector();
+    label_ = detid.label();
+    auto stage1s = es.geometry->getStage1FpgasFromStage2Fpga(id);
+    stage1_n_ = stage1s.size();
+    stage1s_.resize(stage1s.size());
+    std::copy(stage1s.begin(), stage1s.end(), stage1s_.begin());
+
+    tree_->Fill();
+    clear();
+  }
+}
+
+void HGCalTriggerGeoTesterBackendStage2::check(const HGCalTriggerGeoTesterEventSetup& es) {
+  edm::LogPrint("GeoTesterBackendStage2") << "Checking Stage 2";
+  // Create list of modules from valid cells
+  std::unordered_set<uint32_t> modules;
+  for (const auto& id : es.geometry->eeGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  for (const auto& id : es.geometry->hsiGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  for (const auto& id : es.geometry->hscGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  std::unordered_map<uint32_t, std::unordered_set<uint32_t>> stage2_to_stage1;
+  for (const auto& id : modules) {
+    if (es.geometry->disconnectedModule(id))
+      continue;
+    auto s1 = es.geometry->getStage1FpgaFromModule(id);
+    auto s2s = es.geometry->getStage2FpgasFromStage1Fpga(s1);
+    for (auto s2 : s2s) {
+      auto itr_insert = stage2_to_stage1.emplace(s2, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(s1);
+    }
+  }
+
+  // Check consistency of Stage 1 <-> Stage 2 mapping
+  for (const auto& [stage2id, stage1s] : stage2_to_stage1) {
+    HGCalTriggerGeometryBase::geom_set stage1_from_stage2 = es.geometry->getStage1FpgasFromStage2Fpga(stage2id);
+    for (auto stage1 : stage1s) {
+      if (stage1_from_stage2.find(stage1) == stage1_from_stage2.end()) {
+        errors_.fill(HGCalTriggerGeoTesterErrors::MissingStage1InStage2FPGA, stage2id);
+      }
+    }
+    for (auto stage1 : stage1_from_stage2) {
+      if (stage1s.find(stage1) == stage1s.end()) {
+        errors_.fill(HGCalTriggerGeoTesterErrors::InvalidStage1InStage2FPGA, stage2id);
+      }
+    }
+  }
+}
+
+void HGCalTriggerGeoTesterBackendStage2::clear() {
+  id_ = 0;
+  errorbits_ = 0;
+  label_ = 0;
+  zside_ = 0;
+  sector_ = 0;
+  type_ = 0;
+  stage1_n_ = 0;
+  stage1s_.clear();
+}

--- a/L1Trigger/L1THGCal/test/geometry/HGCalTriggerGeoTesterCells.cc
+++ b/L1Trigger/L1THGCal/test/geometry/HGCalTriggerGeoTesterCells.cc
@@ -1,0 +1,349 @@
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeoTesterBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+
+class HGCalTriggerGeoTesterCells : public HGCalTriggerGeoTesterBase {
+public:
+  HGCalTriggerGeoTesterCells(const edm::ParameterSet& conf);
+  ~HGCalTriggerGeoTesterCells() override{};
+  void initialize(TTree*, const edm::ParameterSet&) final;
+  void check(const HGCalTriggerGeoTesterEventSetup& es) final;
+  void fill(const HGCalTriggerGeoTesterEventSetup& es) final;
+
+private:
+  void clear() final;
+  bool validCellIdFromPosition(unsigned cell_id, const HGCalTriggerGeoTesterEventSetup& es) const;
+
+  unsigned id_ = 0;
+  unsigned errorbits_ = 0;
+  int valid_ = 0;
+  int zside_ = 0;
+  int subdet_ = 0;
+  int layer_ = 0;
+  int u_ = 0;
+  int v_ = 0;
+  int ieta_ = 0;
+  int iphi_ = 0;
+  int waferU_ = 0;
+  int waferV_ = 0;
+  int type_ = 0;
+  unsigned tcid_ = 0;
+  unsigned modid_ = 0;
+  float x_ = 0.;
+  float y_ = 0.;
+  float z_ = 0.;
+  float eta_ = 0.;
+  float phi_ = 0.;
+  int corners_n_ = 0;
+  std::vector<float> corners_x_;
+  std::vector<float> corners_y_;
+  std::vector<float> corners_z_;
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerGeoTesterFactory, HGCalTriggerGeoTesterCells, "HGCalTriggerGeoTesterCells");
+
+HGCalTriggerGeoTesterCells::HGCalTriggerGeoTesterCells(const edm::ParameterSet& conf)
+    : HGCalTriggerGeoTesterBase(conf) {}
+
+void HGCalTriggerGeoTesterCells::initialize(TTree* tree, const edm::ParameterSet& conf) {
+  tree_ = tree;
+
+  tree_->Branch("valid", &valid_, "valid/I");
+  tree_->Branch("id", &id_, "id/i");
+  tree_->Branch("errorbits", &errorbits_, "errorbits/i");
+  tree_->Branch("zside", &zside_, "zside/I");
+  tree_->Branch("subdet", &subdet_, "subdet/I");
+  tree_->Branch("layer", &layer_, "layer/I");
+  tree_->Branch("u", &u_, "u/I");
+  tree_->Branch("v", &v_, "v/I");
+  tree_->Branch("ieta", &ieta_, "ieta/I");
+  tree_->Branch("iphi", &iphi_, "iphi/I");
+  tree_->Branch("waferU", &waferU_, "waferU/I");
+  tree_->Branch("waferV", &waferV_, "waferV/I");
+  tree_->Branch("type", &type_, "type/i");
+  tree_->Branch("tcid", &tcid_, "tcid/i");
+  tree_->Branch("modid", &modid_, "modid/I");
+  tree_->Branch("x", &x_, "x/F");
+  tree_->Branch("y", &y_, "y/F");
+  tree_->Branch("z", &z_, "z/F");
+  tree_->Branch("eta", &eta_, "eta/F");
+  tree_->Branch("phi", &phi_, "phi/F");
+  tree_->Branch("corners_n", &corners_n_, "corners_n/I");
+  tree_->Branch("corners_x", &corners_x_);
+  tree_->Branch("corners_y", &corners_y_);
+  tree_->Branch("corners_z", &corners_z_);
+}
+
+void HGCalTriggerGeoTesterCells::fill(const HGCalTriggerGeoTesterEventSetup& es) {
+  clear();
+  // Loop over cells
+  edm::LogPrint("GeoTester") << "Filling cells tree";
+  // EE
+  for (const auto& id : es.geometry->eeGeometry()->getValidDetIds()) {
+    valid_ = es.geometry->eeTopology().valid(id);
+    id_ = id.rawId();
+    const auto error_itr = errors_.detids().find(id);
+    if (error_itr != errors_.detids().end()) {
+      for (const auto& error : error_itr->second) {
+        errorbits_ |= (0x1 << error);
+      }
+    }
+    HGCSiliconDetId detid(id);
+    zside_ = detid.zside();
+    subdet_ = detid.subdet();
+    layer_ = detid.layer();
+    u_ = detid.cellU();
+    v_ = detid.cellV();
+    ieta_ = -999;
+    iphi_ = -999;
+    waferU_ = detid.waferU();
+    waferV_ = detid.waferV();
+    type_ = detid.type();
+    tcid_ = es.geometry->getTriggerCellFromCell(id);
+    modid_ = es.geometry->getModuleFromTriggerCell(tcid_);
+    //
+    GlobalPoint center = es.geometry->eeGeometry()->getPosition(id);
+    x_ = center.x();
+    y_ = center.y();
+    z_ = center.z();
+    eta_ = center.eta();
+    phi_ = center.phi();
+    //
+    std::vector<GlobalPoint> corners = es.geometry->eeGeometry()->getCorners(id);
+    corners_n_ = corners.size();
+    corners_x_.reserve(corners_n_);
+    corners_y_.reserve(corners_n_);
+    corners_z_.reserve(corners_n_);
+    for (const auto& corner : corners) {
+      corners_x_.emplace_back(corner.x());
+      corners_y_.emplace_back(corner.y());
+      corners_z_.emplace_back(corner.z());
+    }
+    tree_->Fill();
+    clear();
+  }
+  for (const auto& id : es.geometry->hsiGeometry()->getValidDetIds()) {
+    valid_ = es.geometry->hsiTopology().valid(id);
+    id_ = id.rawId();
+    const auto error_itr = errors_.detids().find(id);
+    if (error_itr != errors_.detids().end()) {
+      for (const auto& error : error_itr->second) {
+        errorbits_ |= (0x1 << error);
+      }
+    }
+    HGCSiliconDetId detid(id);
+    zside_ = detid.zside();
+    subdet_ = detid.subdet();
+    layer_ = detid.layer();
+    u_ = detid.cellU();
+    v_ = detid.cellV();
+    ieta_ = -999;
+    iphi_ = -999;
+    waferU_ = detid.waferU();
+    waferV_ = detid.waferV();
+    type_ = detid.type();
+    tcid_ = es.geometry->getTriggerCellFromCell(id_);
+    modid_ = es.geometry->getModuleFromTriggerCell(tcid_);
+    //
+    GlobalPoint center = es.geometry->hsiGeometry()->getPosition(id);
+    x_ = center.x();
+    y_ = center.y();
+    z_ = center.z();
+    eta_ = center.eta();
+    phi_ = center.phi();
+    //
+    std::vector<GlobalPoint> corners = es.geometry->hsiGeometry()->getCorners(id);
+    corners_n_ = corners.size();
+    corners_x_.reserve(corners_n_);
+    corners_y_.reserve(corners_n_);
+    corners_z_.reserve(corners_n_);
+    for (const auto& corner : corners) {
+      corners_x_.emplace_back(corner.x());
+      corners_y_.emplace_back(corner.y());
+      corners_z_.emplace_back(corner.z());
+    }
+    tree_->Fill();
+    clear();
+  }
+
+  if (es.geometry->isWithNoseGeometry()) {
+    for (const auto& id : es.geometry->noseGeometry()->getValidDetIds()) {
+      valid_ = es.geometry->noseTopology().valid(id);
+      id_ = id.rawId();
+      const auto error_itr = errors_.detids().find(id);
+      if (error_itr != errors_.detids().end()) {
+        for (const auto& error : error_itr->second) {
+          errorbits_ |= (0x1 << error);
+        }
+      }
+      HFNoseDetId detid(id);
+      zside_ = detid.zside();
+      subdet_ = detid.subdet();
+      layer_ = detid.layer();
+      u_ = detid.cellU();
+      v_ = detid.cellV();
+      ieta_ = -999;
+      iphi_ = -999;
+      waferU_ = detid.waferU();
+      waferV_ = detid.waferV();
+      type_ = detid.type();
+      tcid_ = es.geometry->getTriggerCellFromCell(id_);
+      modid_ = es.geometry->getModuleFromTriggerCell(tcid_);
+      //
+      GlobalPoint center = es.geometry->noseGeometry()->getPosition(id);
+      x_ = center.x();
+      y_ = center.y();
+      z_ = center.z();
+      eta_ = center.eta();
+      phi_ = center.phi();
+      //
+      std::vector<GlobalPoint> corners = es.geometry->noseGeometry()->getCorners(id);
+      corners_n_ = corners.size();
+      corners_x_.reserve(corners_n_);
+      corners_y_.reserve(corners_n_);
+      corners_z_.reserve(corners_n_);
+      for (const auto& corner : corners) {
+        corners_x_.emplace_back(corner.x());
+        corners_y_.emplace_back(corner.y());
+        corners_z_.emplace_back(corner.z());
+      }
+      tree_->Fill();
+      clear();
+    }
+  }
+  for (const auto& id : es.geometry->hscGeometry()->getValidDetIds()) {
+    valid_ = es.geometry->hscTopology().valid(id);
+    id_ = id.rawId();
+    const auto error_itr = errors_.detids().find(id);
+    if (error_itr != errors_.detids().end()) {
+      for (const auto& error : error_itr->second) {
+        errorbits_ |= (0x1 << error);
+      }
+    }
+    HGCScintillatorDetId detid(id);
+    zside_ = detid.zside();
+    subdet_ = detid.subdet();
+    layer_ = detid.layer();
+    u_ = -999;
+    v_ = -999;
+    ieta_ = detid.ieta();
+    iphi_ = detid.iphi();
+    waferU_ = -999;
+    waferV_ = -999;
+    type_ = detid.type();
+    tcid_ = es.geometry->getTriggerCellFromCell(id_);
+    modid_ = es.geometry->getModuleFromTriggerCell(tcid_);
+    //
+    GlobalPoint center = es.geometry->hscGeometry()->getPosition(id);
+    x_ = center.x();
+    y_ = center.y();
+    z_ = center.z();
+    eta_ = center.eta();
+    phi_ = center.phi();
+    //
+    std::vector<GlobalPoint> corners = es.geometry->hscGeometry()->getCorners(id);
+    corners_n_ = corners.size();
+    corners_x_.reserve(corners_n_);
+    corners_y_.reserve(corners_n_);
+    corners_z_.reserve(corners_n_);
+    for (const auto& corner : corners) {
+      corners_x_.emplace_back(corner.x());
+      corners_y_.emplace_back(corner.y());
+      corners_z_.emplace_back(corner.z());
+    }
+    tree_->Fill();
+    clear();
+  }
+}
+
+void HGCalTriggerGeoTesterCells::check(const HGCalTriggerGeoTesterEventSetup& es) {
+  edm::LogPrint("GeoTester") << "Checking cells";
+  for (const auto& id : es.geometry->eeGeometry()->getValidDetIds()) {
+    if (!es.geometry->eeTopology().valid(id)) {
+      errors_.fill(HGCalTriggerGeoTesterErrors::CellValidity, id);
+    }
+    if (!validCellIdFromPosition(id, es)) {
+      errors_.fill(HGCalTriggerGeoTesterErrors::CellValidity, id);
+    }
+  }
+
+  for (const auto& id : es.geometry->hsiGeometry()->getValidDetIds()) {
+    if (!es.geometry->hsiTopology().valid(id)) {
+      errors_.fill(HGCalTriggerGeoTesterErrors::CellValidity, id);
+    }
+    if (!validCellIdFromPosition(id, es)) {
+      errors_.fill(HGCalTriggerGeoTesterErrors::CellValidity, id);
+    }
+  }
+
+  for (const auto& id : es.geometry->hscGeometry()->getValidDetIds()) {
+    if (!es.geometry->hscTopology().valid(id)) {
+      errors_.fill(HGCalTriggerGeoTesterErrors::CellValidity, id);
+    }
+    if (!validCellIdFromPosition(id, es)) {
+      errors_.fill(HGCalTriggerGeoTesterErrors::CellValidity, id);
+    }
+  }
+
+  if (es.geometry->isWithNoseGeometry()) {
+    for (const auto& id : es.geometry->noseGeometry()->getValidDetIds()) {
+      if (!es.geometry->noseTopology().valid(id)) {
+        errors_.fill(HGCalTriggerGeoTesterErrors::CellValidity, id);
+      }
+      if (!validCellIdFromPosition(id, es)) {
+        errors_.fill(HGCalTriggerGeoTesterErrors::CellValidity, id);
+      }
+    }
+  }
+}
+
+bool HGCalTriggerGeoTesterCells::validCellIdFromPosition(unsigned cell_id,
+                                                         const HGCalTriggerGeoTesterEventSetup& es) const {
+  float threshold = 0.1;
+  float cell_z = 0.;
+  unsigned subdet = DetId(cell_id).det();
+  switch (subdet) {
+    case DetId::HGCalEE:
+      cell_z = GlobalPoint(es.geometry->eeGeometry()->getPosition(cell_id).basicVector()).z();
+      break;
+    case DetId::HGCalHSi:
+      cell_z = GlobalPoint(es.geometry->hsiGeometry()->getPosition(cell_id).basicVector()).z();
+      break;
+    case DetId::HGCalHSc:
+      cell_z = GlobalPoint(es.geometry->hscGeometry()->getPosition(cell_id).basicVector()).z();
+      break;
+    case DetId::Forward:
+      cell_z = GlobalPoint(es.geometry->noseGeometry()->getPosition(cell_id).basicVector()).z();
+      break;
+    default:
+      break;
+  }
+  bool is_valid = (std::abs(cell_z) > threshold);
+  return is_valid;
+}
+
+void HGCalTriggerGeoTesterCells::clear() {
+  id_ = 0;
+  valid_ = 0;
+  errorbits_ = 0;
+  zside_ = 0;
+  subdet_ = 0;
+  layer_ = 0;
+  u_ = 0;
+  v_ = 0;
+  ieta_ = 0;
+  iphi_ = 0;
+  waferU_ = 0;
+  waferV_ = 0;
+  type_ = 0;
+  tcid_ = 0;
+  modid_ = 0;
+  x_ = 0.;
+  y_ = 0.;
+  z_ = 0.;
+  eta_ = 0.;
+  phi_ = 0.;
+  corners_n_ = 0;
+  corners_x_.clear();
+  corners_y_.clear();
+  corners_z_.clear();
+}

--- a/L1Trigger/L1THGCal/test/geometry/HGCalTriggerGeoTesterManager.cc
+++ b/L1Trigger/L1THGCal/test/geometry/HGCalTriggerGeoTesterManager.cc
@@ -1,0 +1,64 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeoTesterBase.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "SimGeneral/HepPDTRecord/interface/PDTRecord.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+class HGCalTriggerGeoTesterManager : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
+public:
+  typedef std::unique_ptr<HGCalTriggerGeoTesterBase> tester_ptr;
+
+public:
+  explicit HGCalTriggerGeoTesterManager(const edm::ParameterSet& conf);
+  ~HGCalTriggerGeoTesterManager() override = default;
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  void endRun(const edm::Run&, const edm::EventSetup&) override {}
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  std::vector<std::pair<tester_ptr, TTree*>> testers_;
+
+  HGCalTriggerGeoTesterEventSetup tester_es_;
+  const edm::ESGetToken<HGCalTriggerGeometryBase, CaloGeometryRecord> triggerGeomToken_;
+};
+
+DEFINE_FWK_MODULE(HGCalTriggerGeoTesterManager);
+
+HGCalTriggerGeoTesterManager::HGCalTriggerGeoTesterManager(const edm::ParameterSet& conf)
+    : triggerGeomToken_(esConsumes<HGCalTriggerGeometryBase, CaloGeometryRecord, edm::Transition::BeginRun>()) {
+  usesResource("TFileService");
+  edm::Service<TFileService> file_service;
+  const std::vector<edm::ParameterSet>& tester_cfgs = conf.getParameterSetVector("Testers");
+  for (const auto& tester_cfg : tester_cfgs) {
+    const std::string& tester_name = tester_cfg.getParameter<std::string>("TesterName");
+    TTree* tree = file_service->make<TTree>(tester_name.c_str(), tester_name.c_str());
+    testers_.emplace_back(HGCalTriggerGeoTesterFactory::get()->create(tester_name, tester_cfg), tree);
+    testers_.back().first->initialize(tree, tester_cfg);
+  }
+}
+
+void HGCalTriggerGeoTesterManager::beginRun(const edm::Run& run, const edm::EventSetup& es) {
+  tester_es_.geometry = es.getHandle(triggerGeomToken_);
+  for (auto& [tester, tree] : testers_) {
+    edm::LogPrint("HGCalTriggerGeoTester") << "Running '" << tester->name() << "' tester";
+    tester->check(tester_es_);
+    tester->fill(tester_es_);
+    for (const auto& [error, detids] : tester->errors().errors()) {
+      edm::LogError("HGCalTriggerGeoTester")
+          << HGCalTriggerGeoTesterErrors::messages.at(error) << " for " << detids.size() << " items"
+          << "\n Please check the produced ntuples for more details";
+    }
+  }
+}
+
+void HGCalTriggerGeoTesterManager::analyze(const edm::Event& e, const edm::EventSetup& es) {}

--- a/L1Trigger/L1THGCal/test/geometry/HGCalTriggerGeoTesterModules.cc
+++ b/L1Trigger/L1THGCal/test/geometry/HGCalTriggerGeoTesterModules.cc
@@ -1,0 +1,237 @@
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerModuleDetId.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeoTesterBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+class HGCalTriggerGeoTesterModules : public HGCalTriggerGeoTesterBase {
+public:
+  HGCalTriggerGeoTesterModules(const edm::ParameterSet& conf);
+  ~HGCalTriggerGeoTesterModules() override{};
+  void initialize(TTree*, const edm::ParameterSet&) final;
+  void check(const HGCalTriggerGeoTesterEventSetup& es) final;
+  void fill(const HGCalTriggerGeoTesterEventSetup& es) final;
+
+private:
+  void clear() final;
+
+  HGCalTriggerTools triggerTools_;
+
+  unsigned id_ = 0;
+  unsigned errorbits_ = 0;
+  int disconnected_ = 0;
+  int zside_ = 0;
+  int subdet_ = 0;
+  int sector_ = 0;
+  int layer_ = 0;
+  unsigned stage1_ = 0;
+  unsigned elinks_n_ = 0;
+  int u_ = 0;
+  int v_ = 0;
+  int ieta_ = 0;
+  int iphi_ = 0;
+  int type_ = 0;
+  float x_ = 0.;
+  float y_ = 0.;
+  float z_ = 0.;
+  float eta_ = 0.;
+  float phi_ = 0.;
+  int cells_n_ = 0;
+  int triggercells_n_ = 0;
+  int lpgbts_n_ = 0;
+  std::vector<uint32_t> cells_;
+  std::vector<uint32_t> triggercells_;
+  std::vector<uint32_t> lpgbts_;
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerGeoTesterFactory, HGCalTriggerGeoTesterModules, "HGCalTriggerGeoTesterModules");
+
+HGCalTriggerGeoTesterModules::HGCalTriggerGeoTesterModules(const edm::ParameterSet& conf)
+    : HGCalTriggerGeoTesterBase(conf) {}
+
+void HGCalTriggerGeoTesterModules::initialize(TTree* tree, const edm::ParameterSet& conf) {
+  tree_ = tree;
+
+  tree_->Branch("id", &id_, "id/i");
+  tree_->Branch("errorbits", &errorbits_, "errorbits/i");
+  tree_->Branch("disconnected", &disconnected_, "disconnected/I");
+  tree_->Branch("zside", &zside_, "zside/I");
+  tree_->Branch("subdet", &subdet_, "subdet/I");
+  tree_->Branch("sector", &sector_, "sector/I");
+  tree_->Branch("layer", &layer_, "layer/I");
+  tree_->Branch("stage1", &stage1_, "stage1/i");
+  tree_->Branch("elinks_n", &elinks_n_, "elinks_n/I");
+  tree_->Branch("u", &u_, "u/I");
+  tree_->Branch("v", &v_, "v/I");
+  tree_->Branch("ieta", &ieta_, "ieta/I");
+  tree_->Branch("iphi", &iphi_, "iphi/I");
+  tree_->Branch("type", &type_, "type/i");
+  tree_->Branch("x", &x_, "x/F");
+  tree_->Branch("y", &y_, "y/F");
+  tree_->Branch("z", &z_, "z/F");
+  tree_->Branch("eta", &eta_, "eta/F");
+  tree_->Branch("phi", &phi_, "phi/F");
+  tree_->Branch("cells_n", &cells_n_, "cells_n/I");
+  tree_->Branch("triggercells_n", &triggercells_n_, "triggercells_n/I");
+  tree_->Branch("lpgbts_n", &lpgbts_n_, "lpgbts_n/I");
+  tree_->Branch("cells", &cells_);
+  tree_->Branch("triggercells", &triggercells_);
+  tree_->Branch("lpgbts", &lpgbts_);
+}
+
+void HGCalTriggerGeoTesterModules::fill(const HGCalTriggerGeoTesterEventSetup& es) {
+  clear();
+  edm::LogPrint("TreeFilling") << "Filling modules tree";
+  // Create list of modules from valid cells
+  std::unordered_set<uint32_t> modules;
+  for (const auto& id : es.geometry->eeGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  for (const auto& id : es.geometry->hsiGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  for (const auto& id : es.geometry->hscGeometry()->getValidDetIds()) {
+    modules.insert(es.geometry->getModuleFromCell(id));
+  }
+  for (const auto& id : modules) {
+    HGCalTriggerModuleDetId detid(id);
+    const auto error_itr = errors_.detids().find(id);
+    if (error_itr != errors_.detids().end()) {
+      for (const auto& error : error_itr->second) {
+        errorbits_ |= (0x1 << error);
+      }
+    }
+    disconnected_ = es.geometry->disconnectedModule(id);
+    id_ = id;
+    zside_ = detid.zside();
+    subdet_ = detid.triggerSubdetId();
+    type_ = detid.type();
+    sector_ = detid.sector();
+    layer_ = triggerTools_.layerWithOffset(id);
+    if (!es.geometry->disconnectedModule(id)) {
+      stage1_ = es.geometry->getStage1FpgaFromModule(id);
+      elinks_n_ = es.geometry->getLinksInModule(id);
+    }
+    if (triggerTools_.isSilicon(id)) {
+      u_ = detid.moduleU();
+      v_ = detid.moduleV();
+      ieta_ = -999;
+      iphi_ = -999;
+    } else if (triggerTools_.isScintillator(id)) {
+      u_ = -999;
+      v_ = -999;
+      ieta_ = detid.eta();
+      iphi_ = detid.phi();
+    } else {
+      throw cms::Exception("InvalidHGCalTriggerDetid")
+          << "Found unexpected module detid to be filled in HGCal trigger module ntuple.";
+    }
+    auto cells = es.geometry->getCellsFromModule(id);
+    cells_n_ = cells.size();
+    cells_.resize(cells.size());
+    std::copy(cells.begin(), cells.end(), cells_.begin());
+    auto tcs = es.geometry->getTriggerCellsFromModule(id);
+    triggercells_n_ = tcs.size();
+    triggercells_.resize(tcs.size());
+    std::copy(tcs.begin(), tcs.end(), triggercells_.begin());
+    auto lpgbts = es.geometry->getLpgbtsFromModule(id);
+    lpgbts_n_ = lpgbts.size();
+    lpgbts_.resize(lpgbts.size());
+    std::copy(lpgbts.begin(), lpgbts.end(), lpgbts_.begin());
+    //
+    GlobalPoint center = es.geometry->getModulePosition(id);
+    x_ = center.x();
+    y_ = center.y();
+    z_ = center.z();
+    eta_ = center.eta();
+    phi_ = center.phi();
+
+    tree_->Fill();
+    clear();
+  }
+}
+
+void HGCalTriggerGeoTesterModules::check(const HGCalTriggerGeoTesterEventSetup& es) {
+  edm::LogPrint("GeoTesterModules") << "Checking trigger modules";
+  // Create list of modules from valid cells
+  std::unordered_map<uint32_t, std::unordered_set<uint32_t>> modules_to_triggercells;
+  for (const auto& id : es.geometry->eeGeometry()->getValidDetIds()) {
+    if (!es.geometry->eeTopology().valid(id))
+      continue;
+    unsigned tcid = es.geometry->getTriggerCellFromCell(id);
+    unsigned moduleid = es.geometry->getModuleFromTriggerCell(tcid);
+    auto itr_insert = modules_to_triggercells.emplace(moduleid, std::unordered_set<uint32_t>());
+    itr_insert.first->second.emplace(tcid);
+  }
+  for (const auto& id : es.geometry->hsiGeometry()->getValidDetIds()) {
+    if (!es.geometry->hsiTopology().valid(id))
+      continue;
+    unsigned tcid = es.geometry->getTriggerCellFromCell(id);
+    unsigned moduleid = es.geometry->getModuleFromTriggerCell(tcid);
+    auto itr_insert = modules_to_triggercells.emplace(moduleid, std::unordered_set<uint32_t>());
+    itr_insert.first->second.emplace(tcid);
+  }
+  for (const auto& id : es.geometry->hscGeometry()->getValidDetIds()) {
+    if (!es.geometry->hscTopology().valid(id))
+      continue;
+    unsigned tcid = es.geometry->getTriggerCellFromCell(id);
+    unsigned moduleid = es.geometry->getModuleFromTriggerCell(tcid);
+    auto itr_insert = modules_to_triggercells.emplace(moduleid, std::unordered_set<uint32_t>());
+    itr_insert.first->second.emplace(tcid);
+  }
+  // Check consistency of trigger cells included in modules
+  for (const auto& [moduleid, tcs] : modules_to_triggercells) {
+    HGCalTriggerGeometryBase::geom_set tcs_from_module = es.geometry->getTriggerCellsFromModule(moduleid);
+    for (auto tc : tcs) {
+      if (tcs_from_module.find(tc) == tcs_from_module.end()) {
+        errors_.fill(HGCalTriggerGeoTesterErrors::MissingTCInModule, moduleid);
+      }
+    }
+    for (auto tc : tcs_from_module) {
+      if (tcs.find(tc) == tcs.end()) {
+        errors_.fill(HGCalTriggerGeoTesterErrors::InvalidTCInModule, moduleid);
+      }
+    }
+    if (es.geometry->disconnectedModule(moduleid))
+      continue;
+    auto lpgbts = es.geometry->getLpgbtsFromModule(moduleid);
+    if (lpgbts.size() == 0) {
+      errors_.fill(HGCalTriggerGeoTesterErrors::ConnectedModuleWithoutLpgbt, moduleid);
+    }
+    uint32_t stage1 = 0;
+    for (const auto& lpgbt : lpgbts) {
+      uint32_t stage1_tmp = es.geometry->getStage1FpgaFromLpgbt(lpgbt);
+      if (stage1 != 0 && stage1_tmp != stage1) {
+        errors_.fill(HGCalTriggerGeoTesterErrors::ModuleSplitInStage1, moduleid);
+      }
+      stage1 = stage1_tmp;
+    }
+  }
+}
+
+void HGCalTriggerGeoTesterModules::clear() {
+  id_ = 0;
+  errorbits_ = 0;
+  disconnected_ = 0;
+  zside_ = 0;
+  subdet_ = 0;
+  layer_ = 0;
+  stage1_ = 0;
+  elinks_n_ = 0;
+  sector_ = 0;
+  u_ = 0;
+  v_ = 0;
+  ieta_ = 0;
+  iphi_ = 0;
+  type_ = 0;
+  x_ = 0.;
+  y_ = 0.;
+  z_ = 0.;
+  eta_ = 0.;
+  phi_ = 0.;
+  cells_n_ = 0;
+  triggercells_n_ = 0;
+  cells_.clear();
+  triggercells_.clear();
+}

--- a/L1Trigger/L1THGCal/test/geometry/HGCalTriggerGeoTesterTriggerCells.cc
+++ b/L1Trigger/L1THGCal/test/geometry/HGCalTriggerGeoTesterTriggerCells.cc
@@ -1,0 +1,225 @@
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "DataFormats/ForwardDetId/interface/HGCalTriggerDetId.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeometryBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerGeoTesterBase.h"
+#include "L1Trigger/L1THGCal/interface/HGCalTriggerTools.h"
+
+class HGCalTriggerGeoTesterTriggerCells : public HGCalTriggerGeoTesterBase {
+public:
+  HGCalTriggerGeoTesterTriggerCells(const edm::ParameterSet& conf);
+  ~HGCalTriggerGeoTesterTriggerCells() override{};
+  void initialize(TTree*, const edm::ParameterSet&) final;
+  void check(const HGCalTriggerGeoTesterEventSetup& es) final;
+  void fill(const HGCalTriggerGeoTesterEventSetup& es) final;
+
+private:
+  void clear() final;
+
+  HGCalTriggerTools triggerTools_;
+
+  unsigned id_ = 0;
+  int valid_ = 0;
+  unsigned errorbits_ = 0;
+  int disconnected_ = 0;
+  int zside_ = 0;
+  int subdet_ = 0;
+  int layer_ = 0;
+  int u_ = 0;
+  int v_ = 0;
+  int ieta_ = 0;
+  int iphi_ = 0;
+  int waferU_ = 0;
+  int waferV_ = 0;
+  int type_ = 0;
+  unsigned modid_ = 0;
+  float x_ = 0.;
+  float y_ = 0.;
+  float z_ = 0.;
+  float eta_ = 0.;
+  float phi_ = 0.;
+  int cells_n_ = 0;
+  std::vector<uint32_t> cells_;
+};
+
+DEFINE_EDM_PLUGIN(HGCalTriggerGeoTesterFactory, HGCalTriggerGeoTesterTriggerCells, "HGCalTriggerGeoTesterTriggerCells");
+
+HGCalTriggerGeoTesterTriggerCells::HGCalTriggerGeoTesterTriggerCells(const edm::ParameterSet& conf)
+    : HGCalTriggerGeoTesterBase(conf) {}
+
+void HGCalTriggerGeoTesterTriggerCells::initialize(TTree* tree, const edm::ParameterSet& conf) {
+  tree_ = tree;
+
+  tree_->Branch("valid", &valid_, "valid/I");
+  tree_->Branch("disconnected", &disconnected_, "disconnected/I");
+  tree_->Branch("id", &id_, "id/i");
+  tree_->Branch("errorbits", &errorbits_, "errorbits/i");
+  tree_->Branch("zside", &zside_, "zside/I");
+  tree_->Branch("subdet", &subdet_, "subdet/I");
+  tree_->Branch("layer", &layer_, "layer/I");
+  tree_->Branch("u", &u_, "u/I");
+  tree_->Branch("v", &v_, "v/I");
+  tree_->Branch("ieta", &ieta_, "ieta/I");
+  tree_->Branch("iphi", &iphi_, "iphi/I");
+  tree_->Branch("waferU", &waferU_, "waferU/I");
+  tree_->Branch("waferV", &waferV_, "waferV/I");
+  tree_->Branch("type", &type_, "type/i");
+  tree_->Branch("modid", &modid_, "modid/I");
+  tree_->Branch("x", &x_, "x/F");
+  tree_->Branch("y", &y_, "y/F");
+  tree_->Branch("z", &z_, "z/F");
+  tree_->Branch("eta", &eta_, "eta/F");
+  tree_->Branch("phi", &phi_, "phi/F");
+  tree_->Branch("cells_n", &cells_n_, "cells_n/I");
+  tree_->Branch("cells", &cells_);
+}
+
+void HGCalTriggerGeoTesterTriggerCells::fill(const HGCalTriggerGeoTesterEventSetup& es) {
+  clear();
+  edm::LogPrint("TreeFilling") << "Filling trigger cells tree";
+  // Create list of TCs from valid cells
+  std::unordered_set<uint32_t> triggercells;
+  for (const auto& id : es.geometry->eeGeometry()->getValidDetIds()) {
+    triggercells.insert(es.geometry->getTriggerCellFromCell(id));
+  }
+  for (const auto& id : es.geometry->hsiGeometry()->getValidDetIds()) {
+    triggercells.insert(es.geometry->getTriggerCellFromCell(id));
+  }
+  for (const auto& id : es.geometry->hscGeometry()->getValidDetIds()) {
+    triggercells.insert(es.geometry->getTriggerCellFromCell(id));
+  }
+  if (es.geometry->isWithNoseGeometry()) {
+    for (const auto& id : es.geometry->noseGeometry()->getValidDetIds()) {
+      triggercells.insert(es.geometry->getTriggerCellFromCell(id));
+    }
+  }
+  for (const auto& id : triggercells) {
+    DetId detid(id);
+    modid_ = es.geometry->getModuleFromTriggerCell(id);
+    valid_ = es.geometry->validTriggerCell(id);
+    disconnected_ = es.geometry->disconnectedModule(modid_);
+    id_ = id;
+    const auto error_itr = errors_.detids().find(id);
+    if (error_itr != errors_.detids().end()) {
+      for (const auto& error : error_itr->second) {
+        errorbits_ |= (0x1 << error);
+      }
+    }
+    zside_ = triggerTools_.zside(id);
+    layer_ = triggerTools_.layerWithOffset(id);
+    if (detid.det() == DetId::HGCalTrigger) {
+      HGCalTriggerDetId idtrg(id);
+      subdet_ = idtrg.subdet();
+      waferU_ = idtrg.waferU();
+      waferV_ = idtrg.waferV();
+      type_ = idtrg.type();
+      u_ = idtrg.triggerCellU();
+      v_ = idtrg.triggerCellV();
+      ieta_ = -999;
+      iphi_ = -999;
+    } else if (detid.det() == DetId::HGCalHSc) {
+      HGCScintillatorDetId idsci(id);
+      subdet_ = idsci.subdet();
+      waferU_ = -999;
+      waferV_ = -999;
+      type_ = idsci.type();
+      u_ = -999;
+      v_ = -999;
+      ieta_ = idsci.ietaAbs();
+      iphi_ = idsci.iphi();
+    } else {
+      throw cms::Exception("InvalidHGCalTriggerDetid")
+          << "Found unexpected trigger cell detid to be filled in HGCal Trigger Cell ntuple.";
+    }
+    auto cells = es.geometry->getCellsFromTriggerCell(id_);
+    cells_n_ = cells.size();
+    cells_.resize(cells.size());
+    std::copy(cells.begin(), cells.end(), cells_.begin());
+    //
+    GlobalPoint center = es.geometry->getTriggerCellPosition(id);
+    x_ = center.x();
+    y_ = center.y();
+    z_ = center.z();
+    eta_ = center.eta();
+    phi_ = center.phi();
+
+    tree_->Fill();
+    clear();
+  }
+}
+
+void HGCalTriggerGeoTesterTriggerCells::check(const HGCalTriggerGeoTesterEventSetup& es) {
+  edm::LogPrint("GeoTesterTriggerCells") << "Checking trigger cells";
+  // Create list of TCs from valid cells
+  std::unordered_map<uint32_t, std::unordered_set<uint32_t>> triggercells_to_cells;
+  for (const auto& id : es.geometry->eeGeometry()->getValidDetIds()) {
+    if (!es.geometry->eeTopology().valid(id))
+      continue;
+    unsigned tcid = es.geometry->getTriggerCellFromCell(id);
+    auto itr_insert = triggercells_to_cells.emplace(tcid, std::unordered_set<uint32_t>());
+    itr_insert.first->second.emplace(id);
+  }
+  for (const auto& id : es.geometry->hsiGeometry()->getValidDetIds()) {
+    if (!es.geometry->hsiTopology().valid(id))
+      continue;
+    unsigned tcid = es.geometry->getTriggerCellFromCell(id);
+    auto itr_insert = triggercells_to_cells.emplace(tcid, std::unordered_set<uint32_t>());
+    itr_insert.first->second.emplace(id);
+  }
+  for (const auto& id : es.geometry->hscGeometry()->getValidDetIds()) {
+    if (!es.geometry->hscTopology().valid(id))
+      continue;
+    unsigned tcid = es.geometry->getTriggerCellFromCell(id);
+    auto itr_insert = triggercells_to_cells.emplace(tcid, std::unordered_set<uint32_t>());
+    itr_insert.first->second.emplace(id);
+  }
+  if (es.geometry->isWithNoseGeometry()) {
+    for (const auto& id : es.geometry->noseGeometry()->getValidDetIds()) {
+      if (!es.geometry->noseTopology().valid(id))
+        continue;
+      unsigned tcid = es.geometry->getTriggerCellFromCell(id);
+      auto itr_insert = triggercells_to_cells.emplace(tcid, std::unordered_set<uint32_t>());
+      itr_insert.first->second.emplace(id);
+    }
+  }
+
+  // Check consistency of cells included in trigger cell
+  for (const auto& [tcid, cells] : triggercells_to_cells) {
+    HGCalTriggerGeometryBase::geom_set cells_from_tc = es.geometry->getCellsFromTriggerCell(tcid);
+    for (auto cell : cells) {
+      if (cells_from_tc.find(cell) == cells_from_tc.end()) {
+        errors_.fill(HGCalTriggerGeoTesterErrors::MissingCellInTC, tcid);
+      }
+    }
+    for (auto cell : cells_from_tc) {
+      if (cells.find(cell) == cells.end()) {
+        errors_.fill(HGCalTriggerGeoTesterErrors::InvalidCellInTC, tcid);
+      }
+    }
+  }
+}
+
+void HGCalTriggerGeoTesterTriggerCells::clear() {
+  id_ = 0;
+  valid_ = 0;
+  errorbits_ = 0;
+  disconnected_ = 0;
+  zside_ = 0;
+  subdet_ = 0;
+  layer_ = 0;
+  u_ = 0;
+  v_ = 0;
+  ieta_ = 0;
+  iphi_ = 0;
+  waferU_ = 0;
+  waferV_ = 0;
+  type_ = 0;
+  modid_ = 0;
+  x_ = 0.;
+  y_ = 0.;
+  z_ = 0.;
+  eta_ = 0.;
+  phi_ = 0.;
+  cells_n_ = 0;
+  cells_.clear();
+}

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV11_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV11_cfg.py
@@ -1,0 +1,99 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C9_cff import Phase2C9
+process = cms.Process('SIM',Phase2C9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D49Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D49_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Additional output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("test_triggergeom.root")
+    )
+
+MessageLogger = cms.Service("MessageLogger")
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T15', '')
+
+process.endjob_step = cms.EndPath(process.endOfProcess)
+
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+# Eventually modify default geometry parameters
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp3
+process = custom_geometry_V11_Imp3(process)
+
+tester_cells = cms.PSet(
+    TesterName = cms.string('HGCalTriggerGeoTesterCells')
+)
+tester_triggercells = cms.PSet(
+    TesterName = cms.string('HGCalTriggerGeoTesterTriggerCells')
+)
+tester_modules = cms.PSet(
+    TesterName = cms.string('HGCalTriggerGeoTesterModules')
+)
+
+tester_stage1 = cms.PSet(
+    TesterName = cms.string('HGCalTriggerGeoTesterBackendStage1')
+)
+
+tester_stage2 = cms.PSet(
+    TesterName = cms.string('HGCalTriggerGeoTesterBackendStage2')
+)
+
+process.L1THGCaltriggergeomtester = cms.EDAnalyzer(
+    "HGCalTriggerGeoTesterManager", 
+    Testers = cms.VPSet(
+        tester_cells,
+        tester_triggercells,
+        tester_modules,
+        tester_stage1,
+        tester_stage2,
+    )
+)
+process.test_step = cms.Path(process.L1THGCaltriggergeomtester)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.test_step,process.endjob_step)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV16_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV16_cfg.py
@@ -1,0 +1,101 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+process = cms.Process('DIGI',Phase2C17I13M9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D88Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D88_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedHLLHC14TeV_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.SimIdeal_cff')
+process.load('Configuration.StandardSequences.Digi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.DigiToRaw_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.20 $'),
+    annotation = cms.untracked.string('SingleElectronPt10_cfi nevts:10'),
+    name = cms.untracked.string('Applications')
+)
+
+# Output definition
+
+
+# Additional output definition
+process.TFileService = cms.Service(
+    "TFileService",
+    fileName = cms.string("test_triggergeom.root")
+    )
+
+
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T21', '')
+
+process.endjob_step = cms.EndPath(process.endOfProcess)
+
+process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
+# Eventually modify default geometry parameters
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp3
+process = custom_geometry_V11_Imp3(process)
+
+tester_cells = cms.PSet(
+    TesterName = cms.string('HGCalTriggerGeoTesterCells')
+)
+tester_triggercells = cms.PSet(
+    TesterName = cms.string('HGCalTriggerGeoTesterTriggerCells')
+)
+tester_modules = cms.PSet(
+    TesterName = cms.string('HGCalTriggerGeoTesterModules')
+)
+
+tester_stage1 = cms.PSet(
+    TesterName = cms.string('HGCalTriggerGeoTesterBackendStage1')
+)
+
+tester_stage2 = cms.PSet(
+    TesterName = cms.string('HGCalTriggerGeoTesterBackendStage2')
+)
+
+process.L1THGCaltriggergeomtester = cms.EDAnalyzer(
+    "HGCalTriggerGeoTesterManager", 
+    Testers = cms.VPSet(
+        tester_cells,
+        tester_triggercells,
+        tester_modules,
+        tester_stage1,
+        tester_stage2,
+    )
+)
+process.test_step = cms.Path(process.L1THGCaltriggergeomtester)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.test_step,process.endjob_step)
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)


### PR DESCRIPTION
- Complete refactoring of the geometry testing utility, with modularity in mind
- Similar code architecture as used for the ntuplizers
  - With different plugins for different geometry objects to be tested / checked
  - Each of these plugins contains two main methods, one that performs geometry checks and one that fills geometry objects in output ntuples
- In addition to an improved modularity and readability the main updates compared to the existing tester are
  - Added more comprehensive consistency mapping checks
  - Finding an issue doesn't stop the process and all issues are summarized and reported at the end
  - Errors are filled in the output ntuples, with specific error codes for each type of error, such that they can be investigated downstream
  - The mapping between objects is filled in the ntuples (cells <-> TCs <-> modules <-> Stage1 <-> Stage2), also to enable downstream detailed checks   

---
- One thing to note: many issues are reported at various stages when running with the V16 geometry, but I didn't check them yet

FYI @EmyrClement @indra-ehep 