### PR TITLE
Fix cell validity check in TCs

### DIFF
--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -350,7 +350,9 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getCellsFromTrigg
       std::vector<int> cellvs = trigger_cell_trig_id.cellV();
       for (unsigned ic = 0; ic < cellus.size(); ic++) {
         HGCSiliconDetId cell_det_id(cell_det, zside, type, layer, waferu, waferv, cellus[ic], cellvs[ic]);
-        cell_det_ids.emplace(cell_det_id);
+        if (validCellId(cell_det, cell_det_id)) {
+          cell_det_ids.emplace(cell_det_id);
+        }
       }
     }
   }


### PR DESCRIPTION
- Following comments in PR #114, make the fix checking the validity of cells in TCs as a dedicated PR
- It impacts the position of TCs and module sums in partial modules, and therefore affects most notably the reconstruction of towers from module sums based on their $\eta,\phi$ values.