### PR TITLE
Correct some inconsistencies in V16 geometry

### DIFF
--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV16Imp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV16Imp1.cc
@@ -146,8 +146,8 @@ void HGCalTriggerGeometryV16Imp1::reset() {
 }
 
 void HGCalTriggerGeometryV16Imp1::initialize(const HGCalGeometry* hgc_ee_geometry,
-                                            const HGCalGeometry* hgc_hsi_geometry,
-                                            const HGCalGeometry* hgc_hsc_geometry) {
+                                             const HGCalGeometry* hgc_hsi_geometry,
+                                             const HGCalGeometry* hgc_hsc_geometry) {
   setEEGeometry(hgc_ee_geometry);
   setHSiGeometry(hgc_hsi_geometry);
   setHScGeometry(hgc_hsc_geometry);
@@ -170,9 +170,9 @@ void HGCalTriggerGeometryV16Imp1::initialize(const HGCalGeometry* hgc_ee_geometr
 }
 
 void HGCalTriggerGeometryV16Imp1::initialize(const HGCalGeometry* hgc_ee_geometry,
-                                            const HGCalGeometry* hgc_hsi_geometry,
-                                            const HGCalGeometry* hgc_hsc_geometry,
-                                            const HGCalGeometry* hgc_nose_geometry) {
+                                             const HGCalGeometry* hgc_hsi_geometry,
+                                             const HGCalGeometry* hgc_hsc_geometry,
+                                             const HGCalGeometry* hgc_nose_geometry) {
   setEEGeometry(hgc_ee_geometry);
   setHSiGeometry(hgc_hsi_geometry);
   setHScGeometry(hgc_hsc_geometry);
@@ -680,7 +680,8 @@ std::vector<unsigned> HGCalTriggerGeometryV16Imp1::getLpgbtsFromStage1Fpga(const
   return lpgbt_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV16Imp1::getModulesFromStage1Fpga(const unsigned stage1_id) const {
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV16Imp1::getModulesFromStage1Fpga(
+    const unsigned stage1_id) const {
   auto lpgbts = getLpgbtsFromStage1Fpga(stage1_id);
   geom_set modules;
   for (auto lpgbt : lpgbts) {

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV16Imp1.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV16Imp1.cc
@@ -17,9 +17,9 @@
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
-class HGCalTriggerGeometryV9Imp3 : public HGCalTriggerGeometryBase {
+class HGCalTriggerGeometryV16Imp1 : public HGCalTriggerGeometryBase {
 public:
-  HGCalTriggerGeometryV9Imp3(const edm::ParameterSet& conf);
+  HGCalTriggerGeometryV16Imp1(const edm::ParameterSet& conf);
 
   void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) final;
   void initialize(const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*, const HGCalGeometry*) final;
@@ -124,7 +124,7 @@ private:
   unsigned getPreviousSector(const unsigned sector) const;
 };
 
-HGCalTriggerGeometryV9Imp3::HGCalTriggerGeometryV9Imp3(const edm::ParameterSet& conf)
+HGCalTriggerGeometryV16Imp1::HGCalTriggerGeometryV16Imp1(const edm::ParameterSet& conf)
     : HGCalTriggerGeometryBase(conf),
       hSc_triggercell_size_(conf.getParameter<unsigned>("ScintillatorTriggerCellSize")),
       jsonMappingFile_(conf.getParameter<edm::FileInPath>("JsonMappingFile")) {
@@ -132,7 +132,7 @@ HGCalTriggerGeometryV9Imp3::HGCalTriggerGeometryV9Imp3(const edm::ParameterSet& 
   std::move(tmp_vector.begin(), tmp_vector.end(), std::inserter(disconnected_layers_, disconnected_layers_.end()));
 }
 
-void HGCalTriggerGeometryV9Imp3::reset() {
+void HGCalTriggerGeometryV16Imp1::reset() {
   stage2_to_stage1links_.clear();
   stage1links_samesector_.clear();
   stage1link_to_stage2_.clear();
@@ -145,7 +145,7 @@ void HGCalTriggerGeometryV9Imp3::reset() {
   module_to_stage1_.clear();
 }
 
-void HGCalTriggerGeometryV9Imp3::initialize(const HGCalGeometry* hgc_ee_geometry,
+void HGCalTriggerGeometryV16Imp1::initialize(const HGCalGeometry* hgc_ee_geometry,
                                             const HGCalGeometry* hgc_hsi_geometry,
                                             const HGCalGeometry* hgc_hsc_geometry) {
   setEEGeometry(hgc_ee_geometry);
@@ -169,7 +169,7 @@ void HGCalTriggerGeometryV9Imp3::initialize(const HGCalGeometry* hgc_ee_geometry
   fillMaps();
 }
 
-void HGCalTriggerGeometryV9Imp3::initialize(const HGCalGeometry* hgc_ee_geometry,
+void HGCalTriggerGeometryV16Imp1::initialize(const HGCalGeometry* hgc_ee_geometry,
                                             const HGCalGeometry* hgc_hsi_geometry,
                                             const HGCalGeometry* hgc_hsc_geometry,
                                             const HGCalGeometry* hgc_nose_geometry) {
@@ -207,7 +207,7 @@ void HGCalTriggerGeometryV9Imp3::initialize(const HGCalGeometry* hgc_ee_geometry
   }
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::getTriggerCellFromCell(const unsigned cell_id) const {
+unsigned HGCalTriggerGeometryV16Imp1::getTriggerCellFromCell(const unsigned cell_id) const {
   unsigned det = DetId(cell_id).det();
   unsigned trigger_cell_id = 0;
   // Scintillator
@@ -246,11 +246,11 @@ unsigned HGCalTriggerGeometryV9Imp3::getTriggerCellFromCell(const unsigned cell_
   return trigger_cell_id;
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::getModuleFromCell(const unsigned cell_id) const {
+unsigned HGCalTriggerGeometryV16Imp1::getModuleFromCell(const unsigned cell_id) const {
   return getModuleFromTriggerCell(getTriggerCellFromCell(cell_id));
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::getModuleFromTriggerCell(const unsigned trigger_cell_id) const {
+unsigned HGCalTriggerGeometryV16Imp1::getModuleFromTriggerCell(const unsigned trigger_cell_id) const {
   unsigned det = DetId(trigger_cell_id).det();
   int zside = 0;
   unsigned tc_type = 1;
@@ -269,6 +269,13 @@ unsigned HGCalTriggerGeometryV9Imp3::getModuleFromTriggerCell(const unsigned tri
     int ieta = 0;
     int iphi = 0;
     getScintillatoriEtaiPhi(ieta, iphi, tc_eta, tc_phi, layer);
+
+    // HGCalTriggerModuleDetId type only distinguishes between fine and coarse divisions of scintillator (0 or 1 for type)
+    // HGCScintillatorDetId defines two types of coarse divisions (1 or 2, and 0 still meaning fine divisions)
+    // Correct for this here
+    if (tc_type == 2) {
+      tc_type = 1;
+    }
 
     module_id =
         HGCalTriggerModuleDetId(HGCalTriggerSubdetector::HGCalHScTrigger, zside, tc_type, layer, sector, ieta, iphi);
@@ -302,7 +309,7 @@ unsigned HGCalTriggerGeometryV9Imp3::getModuleFromTriggerCell(const unsigned tri
   return module_id;
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getCellsFromTriggerCell(
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV16Imp1::getCellsFromTriggerCell(
     const unsigned trigger_cell_id) const {
   DetId trigger_cell_det_id(trigger_cell_id);
   unsigned det = trigger_cell_det_id.det();
@@ -361,7 +368,7 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getCellsFromTrigg
   return cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getCellsFromModule(const unsigned module_id) const {
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV16Imp1::getCellsFromModule(const unsigned module_id) const {
   geom_set cell_det_ids;
   geom_set trigger_cells = getTriggerCellsFromModule(module_id);
 
@@ -372,7 +379,7 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getCellsFromModul
   return cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_ordered_set HGCalTriggerGeometryV9Imp3::getOrderedCellsFromModule(
+HGCalTriggerGeometryBase::geom_ordered_set HGCalTriggerGeometryV16Imp1::getOrderedCellsFromModule(
     const unsigned module_id) const {
   geom_ordered_set cell_det_ids;
   geom_ordered_set trigger_cells = getOrderedTriggerCellsFromModule(module_id);
@@ -383,7 +390,7 @@ HGCalTriggerGeometryBase::geom_ordered_set HGCalTriggerGeometryV9Imp3::getOrdere
   return cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getTriggerCellsFromModule(
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV16Imp1::getTriggerCellsFromModule(
     const unsigned module_id) const {
   HGCalTriggerModuleDetId hgc_module_id(module_id);
   unsigned subdet = hgc_module_id.triggerSubdetId();
@@ -459,7 +466,7 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getTriggerCellsFr
   return trigger_cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_ordered_set HGCalTriggerGeometryV9Imp3::getOrderedTriggerCellsFromModule(
+HGCalTriggerGeometryBase::geom_ordered_set HGCalTriggerGeometryV16Imp1::getOrderedTriggerCellsFromModule(
     const unsigned module_id) const {
   HGCalTriggerModuleDetId hgc_module_id(module_id);
   unsigned subdet = hgc_module_id.triggerSubdetId();
@@ -537,12 +544,12 @@ HGCalTriggerGeometryBase::geom_ordered_set HGCalTriggerGeometryV9Imp3::getOrdere
   return trigger_cell_det_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getNeighborsFromTriggerCell(
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV16Imp1::getNeighborsFromTriggerCell(
     const unsigned trigger_cell_id) const {
-  throw cms::Exception("FeatureNotImplemented") << "Neighbor search is not implemented in HGCalTriggerGeometryV9Imp3";
+  throw cms::Exception("FeatureNotImplemented") << "Neighbor search is not implemented in HGCalTriggerGeometryV16Imp1";
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::getLinksInModule(const unsigned module_id) const {
+unsigned HGCalTriggerGeometryV16Imp1::getLinksInModule(const unsigned module_id) const {
   HGCalTriggerModuleDetId module_det_id(module_id);
   unsigned subdet = module_det_id.triggerSubdetId();
 
@@ -561,12 +568,12 @@ unsigned HGCalTriggerGeometryV9Imp3::getLinksInModule(const unsigned module_id) 
   return links;
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::getModuleSize(const unsigned module_id) const {
+unsigned HGCalTriggerGeometryV16Imp1::getModuleSize(const unsigned module_id) const {
   unsigned nWafers = 1;
   return nWafers;
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::getNextSector(const unsigned sector) const {
+unsigned HGCalTriggerGeometryV16Imp1::getNextSector(const unsigned sector) const {
   unsigned next_sector = 0;
   if (sector < 2) {
     next_sector = sector + 1;
@@ -574,7 +581,7 @@ unsigned HGCalTriggerGeometryV9Imp3::getNextSector(const unsigned sector) const 
   return next_sector;
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::getPreviousSector(const unsigned sector) const {
+unsigned HGCalTriggerGeometryV16Imp1::getPreviousSector(const unsigned sector) const {
   unsigned previous_sector = 2;
   if (sector > 0) {
     previous_sector = sector - 1;
@@ -582,7 +589,7 @@ unsigned HGCalTriggerGeometryV9Imp3::getPreviousSector(const unsigned sector) co
   return previous_sector;
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage1FpgasFromStage2Fpga(
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV16Imp1::getStage1FpgasFromStage2Fpga(
     const unsigned stage2_id) const {
   geom_set stage1_ids;
 
@@ -594,7 +601,7 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage1FpgasFro
   return stage1_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage2FpgasFromStage1Fpga(
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV16Imp1::getStage2FpgasFromStage1Fpga(
     const unsigned stage1_id) const {
   geom_set stage2_ids;
 
@@ -606,7 +613,7 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage2FpgasFro
   return stage2_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage1LinksFromStage2Fpga(
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV16Imp1::getStage1LinksFromStage2Fpga(
     const unsigned stage2_id) const {
   geom_set stage1link_ids;
   HGCalTriggerBackendDetId id(stage2_id);
@@ -625,7 +632,7 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage1LinksFro
   return stage1link_ids;
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::getStage1FpgaFromStage1Link(const unsigned link_id) const {
+unsigned HGCalTriggerGeometryV16Imp1::getStage1FpgaFromStage1Link(const unsigned link_id) const {
   HGCalTriggerBackendDetId id(link_id);
   unsigned stage1_label = stage1link_to_stage1_.at(id.label());
 
@@ -633,7 +640,7 @@ unsigned HGCalTriggerGeometryV9Imp3::getStage1FpgaFromStage1Link(const unsigned 
       id.zside(), HGCalTriggerBackendDetId::BackendType::Stage1FPGA, id.sector(), stage1_label);
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::getStage2FpgaFromStage1Link(const unsigned link_id) const {
+unsigned HGCalTriggerGeometryV16Imp1::getStage2FpgaFromStage1Link(const unsigned link_id) const {
   HGCalTriggerBackendDetId id(link_id);
   bool same_sector = stage1link_to_stage2_.at(id.label());
   unsigned sector = id.sector();
@@ -645,7 +652,7 @@ unsigned HGCalTriggerGeometryV9Imp3::getStage2FpgaFromStage1Link(const unsigned 
   return HGCalTriggerBackendDetId(id.zside(), HGCalTriggerBackendDetId::BackendType::Stage2FPGA, sector, 0);
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage1LinksFromStage1Fpga(
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV16Imp1::getStage1LinksFromStage1Fpga(
     const unsigned stage1_id) const {
   geom_set stage1link_ids;
   HGCalTriggerBackendDetId id(stage1_id);
@@ -659,7 +666,7 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getStage1LinksFro
   return stage1link_ids;
 }
 
-std::vector<unsigned> HGCalTriggerGeometryV9Imp3::getLpgbtsFromStage1Fpga(const unsigned stage1_id) const {
+std::vector<unsigned> HGCalTriggerGeometryV16Imp1::getLpgbtsFromStage1Fpga(const unsigned stage1_id) const {
   std::vector<unsigned> lpgbt_ids;
   HGCalTriggerBackendDetId id(stage1_id);
 
@@ -673,7 +680,7 @@ std::vector<unsigned> HGCalTriggerGeometryV9Imp3::getLpgbtsFromStage1Fpga(const 
   return lpgbt_ids;
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getModulesFromStage1Fpga(const unsigned stage1_id) const {
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV16Imp1::getModulesFromStage1Fpga(const unsigned stage1_id) const {
   auto lpgbts = getLpgbtsFromStage1Fpga(stage1_id);
   geom_set modules;
   for (auto lpgbt : lpgbts) {
@@ -681,7 +688,7 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getModulesFromSta
   }
   return modules;
 }
-unsigned HGCalTriggerGeometryV9Imp3::getStage1FpgaFromLpgbt(const unsigned lpgbt_id) const {
+unsigned HGCalTriggerGeometryV16Imp1::getStage1FpgaFromLpgbt(const unsigned lpgbt_id) const {
   HGCalTriggerBackendDetId id(lpgbt_id);
   unsigned stage1_label = lpgbt_to_stage1_.at(id.label());
 
@@ -689,7 +696,7 @@ unsigned HGCalTriggerGeometryV9Imp3::getStage1FpgaFromLpgbt(const unsigned lpgbt
       id.zside(), HGCalTriggerBackendDetId::BackendType::Stage1FPGA, id.sector(), stage1_label);
 }
 
-HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getModulesFromLpgbt(const unsigned lpgbt_id) const {
+HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV16Imp1::getModulesFromLpgbt(const unsigned lpgbt_id) const {
   geom_set modules;
   HGCalTriggerBackendDetId id(lpgbt_id);
 
@@ -724,7 +731,7 @@ HGCalTriggerGeometryBase::geom_set HGCalTriggerGeometryV9Imp3::getModulesFromLpg
   return modules;
 }
 
-HGCalTriggerGeometryV9Imp3::geom_set HGCalTriggerGeometryV9Imp3::getLpgbtsFromModule(const unsigned module_id) const {
+HGCalTriggerGeometryV16Imp1::geom_set HGCalTriggerGeometryV16Imp1::getLpgbtsFromModule(const unsigned module_id) const {
   geom_set lpgbt_ids;
   HGCalTriggerModuleDetId id(module_id);
 
@@ -738,7 +745,7 @@ HGCalTriggerGeometryV9Imp3::geom_set HGCalTriggerGeometryV9Imp3::getLpgbtsFromMo
   return lpgbt_ids;
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::getStage1FpgaFromModule(const unsigned module_id) const {
+unsigned HGCalTriggerGeometryV16Imp1::getStage1FpgaFromModule(const unsigned module_id) const {
   HGCalTriggerModuleDetId id(module_id);
 
   unsigned stage1_label =
@@ -748,7 +755,7 @@ unsigned HGCalTriggerGeometryV9Imp3::getStage1FpgaFromModule(const unsigned modu
       id.zside(), HGCalTriggerBackendDetId::BackendType::Stage1FPGA, id.sector(), stage1_label);
 }
 
-GlobalPoint HGCalTriggerGeometryV9Imp3::getTriggerCellPosition(const unsigned trigger_cell_det_id) const {
+GlobalPoint HGCalTriggerGeometryV16Imp1::getTriggerCellPosition(const unsigned trigger_cell_det_id) const {
   unsigned det = DetId(trigger_cell_det_id).det();
 
   // Position: barycenter of the trigger cell.
@@ -780,7 +787,7 @@ GlobalPoint HGCalTriggerGeometryV9Imp3::getTriggerCellPosition(const unsigned tr
   return GlobalPoint(triggerCellVector / cell_ids.size());
 }
 
-GlobalPoint HGCalTriggerGeometryV9Imp3::getModulePosition(const unsigned module_det_id) const {
+GlobalPoint HGCalTriggerGeometryV16Imp1::getModulePosition(const unsigned module_det_id) const {
   unsigned subdet = HGCalTriggerModuleDetId(module_det_id).triggerSubdetId();
   // Position: barycenter of the module.
   Basic3DVector<float> moduleVector(0., 0., 0.);
@@ -810,7 +817,7 @@ GlobalPoint HGCalTriggerGeometryV9Imp3::getModulePosition(const unsigned module_
   return GlobalPoint(moduleVector / cell_ids.size());
 }
 
-void HGCalTriggerGeometryV9Imp3::fillMaps() {
+void HGCalTriggerGeometryV16Imp1::fillMaps() {
   // read json mapping file
   json mapping_config;
   std::ifstream json_input_file(jsonMappingFile_.fullPath());
@@ -830,7 +837,7 @@ void HGCalTriggerGeometryV9Imp3::fillMaps() {
       }
     }
   } catch (const json::exception& e) {
-    edm::LogError("HGCalTriggerGeometryV9Imp3")
+    edm::LogError("HGCalTriggerGeometryV16Imp1")
         << "The mapping input json file does not have the expected structure for the Stage2 block";
   }
 
@@ -843,7 +850,7 @@ void HGCalTriggerGeometryV9Imp3::fillMaps() {
       stage1link_to_stage2_.emplace(link_id, mapping_config.at("Stage1Links").at(link_id).at("Stage2SameSector"));
     }
   } catch (const json::exception& e) {
-    edm::LogError("HGCalTriggerGeometryV9Imp3")
+    edm::LogError("HGCalTriggerGeometryV16Imp1")
         << "The mapping input json file does not have the expected structure for the Stage1Links block";
   }
 
@@ -863,7 +870,7 @@ void HGCalTriggerGeometryV9Imp3::fillMaps() {
     }
 
   } catch (const json::exception& e) {
-    edm::LogError("HGCalTriggerGeometryV9Imp3")
+    edm::LogError("HGCalTriggerGeometryV16Imp1")
         << "The mapping input json file does not have the expected structure for the Stage1 block";
   }
 
@@ -886,13 +893,13 @@ void HGCalTriggerGeometryV9Imp3::fillMaps() {
         auto result = module_to_stage1_.emplace(packed_value, stage1_id);
         if (result.second == false &&
             stage1_id != result.first->second) {  //check that the stage1_id is the same as in the existing map
-          edm::LogError("HGCalTriggerGeometryV9Imp3") << "One module is connected to two separate Stage1 FPGAs";
+          edm::LogError("HGCalTriggerGeometryV16Imp1") << "One module is connected to two separate Stage1 FPGAs";
         }
       }
     }
 
   } catch (const json::exception& e) {
-    edm::LogError("HGCalTriggerGeometryV9Imp3")
+    edm::LogError("HGCalTriggerGeometryV16Imp1")
         << "The mapping input json file does not have the expected structure for the lpGBT block";
   }
 
@@ -915,14 +922,14 @@ void HGCalTriggerGeometryV9Imp3::fillMaps() {
       links_per_module_.emplace(packed_module, num_elinks);
     }
   } catch (const json::exception& e) {
-    edm::LogError("HGCalTriggerGeometryV9Imp3")
+    edm::LogError("HGCalTriggerGeometryV16Imp1")
         << "The mapping input json file does not have the expected structure for the Module block";
   }
 
   json_input_file.close();
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::packLayerSubdetWaferId(unsigned layer, int subdet, int waferU, int waferV) const {
+unsigned HGCalTriggerGeometryV16Imp1::packLayerSubdetWaferId(unsigned layer, int subdet, int waferU, int waferV) const {
   unsigned packed_value = 0;
 
   packed_value |=
@@ -935,7 +942,7 @@ unsigned HGCalTriggerGeometryV9Imp3::packLayerSubdetWaferId(unsigned layer, int 
   return packed_value;
 }
 
-void HGCalTriggerGeometryV9Imp3::unpackLayerSubdetWaferId(
+void HGCalTriggerGeometryV16Imp1::unpackLayerSubdetWaferId(
     unsigned wafer, unsigned& layer, int& subdet, int& waferU, int& waferV) const {
   waferU = (wafer >> HGCalTriggerModuleDetId::kHGCalModuleUOffset) & HGCalTriggerModuleDetId::kHGCalModuleUMask;
   waferV = (wafer >> HGCalTriggerModuleDetId::kHGCalModuleVOffset) & HGCalTriggerModuleDetId::kHGCalModuleVMask;
@@ -944,7 +951,7 @@ void HGCalTriggerGeometryV9Imp3::unpackLayerSubdetWaferId(
   layer = (wafer >> HGCalTriggerModuleDetId::kHGCalLayerOffset) & HGCalTriggerModuleDetId::kHGCalLayerMask;
 }
 
-void HGCalTriggerGeometryV9Imp3::etaphiMappingFromSector0(int& ieta, int& iphi, unsigned sector) const {
+void HGCalTriggerGeometryV16Imp1::etaphiMappingFromSector0(int& ieta, int& iphi, unsigned sector) const {
   if (sector == 0) {
     return;
   }
@@ -955,25 +962,28 @@ void HGCalTriggerGeometryV9Imp3::etaphiMappingFromSector0(int& ieta, int& iphi, 
   }
 }
 
-HGCalGeomRotation::WaferCentring HGCalTriggerGeometryV9Imp3::getWaferCentring(unsigned layer, int subdet) const {
+HGCalGeomRotation::WaferCentring HGCalTriggerGeometryV16Imp1::getWaferCentring(unsigned layer, int subdet) const {
   if (subdet == HGCalTriggerSubdetector::HGCalEETrigger) {  // CE-E
-    return HGCalGeomRotation::WaferCentring::WaferCentred;
+    return HGCalGeomRotation::WaferCentring::WaferCentred;  // All layers are wafer centred
   } else if (subdet == HGCalTriggerSubdetector::HGCalHSiTrigger) {
-    if ((layer % 2) == 1) {  // CE-H Odd
-      return HGCalGeomRotation::WaferCentring::CornerCentredY;
-    } else {  // CE-H Even
+    auto topologyLayerType = hsiTopology().dddConstants().layerType(layer);
+
+    if (topologyLayerType == HGCalTypes::CornerCenterYp)
       return HGCalGeomRotation::WaferCentring::CornerCentredMercedes;
-    }
+    else if (topologyLayerType == HGCalTypes::CornerCenterYm)
+      return HGCalGeomRotation::WaferCentring::CornerCentredY;
+    else
+      return HGCalGeomRotation::WaferCentring::WaferCentred;
+
   } else if (subdet == HGCalTriggerSubdetector::HFNoseTrigger) {  //HFNose
     return HGCalGeomRotation::WaferCentring::WaferCentred;
   } else {
-    edm::LogError("HGCalTriggerGeometryV9Imp3")
-        << "HGCalTriggerGeometryV9Imp3: trigger sub-detector expected to be silicon";
+    edm::LogError("HGCalTriggerGeometryV9") << "HGCalTriggerGeometryV9: trigger sub-detector expected to be silicon";
     return HGCalGeomRotation::WaferCentring::WaferCentred;
   }
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::tcEtaphiMappingToSector0(int& tc_ieta, int& tc_iphi) const {
+unsigned HGCalTriggerGeometryV16Imp1::tcEtaphiMappingToSector0(int& tc_ieta, int& tc_iphi) const {
   unsigned sector = 0;
 
   if (tc_iphi > hSc_tc_layer0_min_ && tc_iphi <= hSc_tc_layer0_min_ + ntc_per_wafer_) {
@@ -998,7 +1008,7 @@ unsigned HGCalTriggerGeometryV9Imp3::tcEtaphiMappingToSector0(int& tc_ieta, int&
   return sector;
 }
 
-void HGCalTriggerGeometryV9Imp3::getScintillatoriEtaiPhi(
+void HGCalTriggerGeometryV16Imp1::getScintillatoriEtaiPhi(
     int& ieta, int& iphi, int tc_eta, int tc_phi, unsigned layer) const {
   iphi = (tc_phi - 1) / hSc_tcs_per_module_phi_;  //Phi index 1-12
 
@@ -1013,11 +1023,11 @@ void HGCalTriggerGeometryV9Imp3::getScintillatoriEtaiPhi(
   }
 }
 
-bool HGCalTriggerGeometryV9Imp3::validTriggerCell(const unsigned trigger_cell_id) const {
+bool HGCalTriggerGeometryV16Imp1::validTriggerCell(const unsigned trigger_cell_id) const {
   return validTriggerCellFromCells(trigger_cell_id);
 }
 
-bool HGCalTriggerGeometryV9Imp3::disconnectedModule(const unsigned module_id) const {
+bool HGCalTriggerGeometryV16Imp1::disconnectedModule(const unsigned module_id) const {
   bool disconnected = false;
   HGCalTriggerModuleDetId id(module_id);
   if (module_to_stage1_.find(packLayerSubdetWaferId(id.layer(), id.triggerSubdetId(), id.moduleU(), id.moduleV())) ==
@@ -1030,7 +1040,7 @@ bool HGCalTriggerGeometryV9Imp3::disconnectedModule(const unsigned module_id) co
   return disconnected;
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::triggerLayer(const unsigned id) const {
+unsigned HGCalTriggerGeometryV16Imp1::triggerLayer(const unsigned id) const {
   unsigned layer = layerWithOffset(id);
 
   if (DetId(id).det() == DetId::HGCalTrigger and
@@ -1044,7 +1054,7 @@ unsigned HGCalTriggerGeometryV9Imp3::triggerLayer(const unsigned id) const {
   return trigger_layers_[layer];
 }
 
-bool HGCalTriggerGeometryV9Imp3::validCell(unsigned cell_id) const {
+bool HGCalTriggerGeometryV16Imp1::validCell(unsigned cell_id) const {
   bool is_valid = false;
   unsigned det = DetId(cell_id).det();
   switch (det) {
@@ -1067,7 +1077,7 @@ bool HGCalTriggerGeometryV9Imp3::validCell(unsigned cell_id) const {
   return is_valid;
 }
 
-bool HGCalTriggerGeometryV9Imp3::validTriggerCellFromCells(const unsigned trigger_cell_id) const {
+bool HGCalTriggerGeometryV16Imp1::validTriggerCellFromCells(const unsigned trigger_cell_id) const {
   // Check the validity of a trigger cell with the
   // validity of the cells. One valid cell in the
   // trigger cell is enough to make the trigger cell
@@ -1083,7 +1093,7 @@ bool HGCalTriggerGeometryV9Imp3::validTriggerCellFromCells(const unsigned trigge
   return is_valid;
 }
 
-bool HGCalTriggerGeometryV9Imp3::validCellId(unsigned subdet, unsigned cell_id) const {
+bool HGCalTriggerGeometryV16Imp1::validCellId(unsigned subdet, unsigned cell_id) const {
   bool is_valid = false;
   switch (subdet) {
     case DetId::HGCalEE:
@@ -1105,7 +1115,7 @@ bool HGCalTriggerGeometryV9Imp3::validCellId(unsigned subdet, unsigned cell_id) 
   return is_valid;
 }
 
-int HGCalTriggerGeometryV9Imp3::detIdWaferType(unsigned det, unsigned layer, short waferU, short waferV) const {
+int HGCalTriggerGeometryV16Imp1::detIdWaferType(unsigned det, unsigned layer, short waferU, short waferV) const {
   int wafer_type = 0;
   switch (det) {
     case DetId::HGCalEE:
@@ -1123,7 +1133,7 @@ int HGCalTriggerGeometryV9Imp3::detIdWaferType(unsigned det, unsigned layer, sho
   return wafer_type;
 }
 
-void HGCalTriggerGeometryV9Imp3::layerWithoutOffsetAndSubdetId(unsigned& layer, int& subdetId, bool isSilicon) const {
+void HGCalTriggerGeometryV16Imp1::layerWithoutOffsetAndSubdetId(unsigned& layer, int& subdetId, bool isSilicon) const {
   if (!isSilicon) {
     layer = layer - heOffset_;
     subdetId = HGCalTriggerSubdetector::HGCalHScTrigger;
@@ -1137,7 +1147,7 @@ void HGCalTriggerGeometryV9Imp3::layerWithoutOffsetAndSubdetId(unsigned& layer, 
   }
 }
 
-unsigned HGCalTriggerGeometryV9Imp3::layerWithOffset(unsigned id) const {
+unsigned HGCalTriggerGeometryV16Imp1::layerWithOffset(unsigned id) const {
   unsigned det = DetId(id).det();
   unsigned layer = 0;
 
@@ -1166,4 +1176,4 @@ unsigned HGCalTriggerGeometryV9Imp3::layerWithOffset(unsigned id) const {
   return layer;
 }
 
-DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory, HGCalTriggerGeometryV9Imp3, "HGCalTriggerGeometryV9Imp3");
+DEFINE_EDM_PLUGIN(HGCalTriggerGeometryFactory, HGCalTriggerGeometryV16Imp1, "HGCalTriggerGeometryV16Imp1");

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -968,21 +968,13 @@ HGCalGeomRotation::WaferCentring HGCalTriggerGeometryV9Imp3::getWaferCentring(un
   } else if (subdet == HGCalTriggerSubdetector::HGCalHSiTrigger) {
     auto topologyLayerType = hsiTopology().dddConstants().layerType(layer);
 
-    if ((layer % 2) == 1) {  // CE-H Odd
-      // Check topology for wafer centred layers, otherwise CornerCentredY
-      if (topologyLayerType == HGCalTypes::WaferCenter || topologyLayerType == HGCalTypes::WaferCenterR ||
-          topologyLayerType == HGCalTypes::WaferCenterB)
-        return HGCalGeomRotation::WaferCentring::WaferCentred;
-      else
-        return HGCalGeomRotation::WaferCentring::CornerCentredY;
-    } else {  // CE-H Even
-      // Check topology for wafer centred layers, otherwise CornerCentredMercedes
-      if (topologyLayerType == HGCalTypes::WaferCenter || topologyLayerType == HGCalTypes::WaferCenterR ||
-          topologyLayerType == HGCalTypes::WaferCenterB)
-        return HGCalGeomRotation::WaferCentring::WaferCentred;
-      else
-        return HGCalGeomRotation::WaferCentring::CornerCentredMercedes;
-    }
+    if (topologyLayerType == HGCalTypes::CornerCenterYp)
+      return HGCalGeomRotation::WaferCentring::CornerCentredMercedes;
+    else if (topologyLayerType == HGCalTypes::CornerCenterYm)
+      return HGCalGeomRotation::WaferCentring::CornerCentredY;
+    else
+      return HGCalGeomRotation::WaferCentring::WaferCentred;
+
   } else if (subdet == HGCalTriggerSubdetector::HFNoseTrigger) {  //HFNose
     return HGCalGeomRotation::WaferCentring::WaferCentred;
   } else {

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -269,6 +269,14 @@ unsigned HGCalTriggerGeometryV9Imp3::getModuleFromTriggerCell(const unsigned tri
     int ieta = 0;
     int iphi = 0;
     getScintillatoriEtaiPhi(ieta, iphi, tc_eta, tc_phi, layer);
+
+    // HGCalTriggerModuleDetId type only distinguishes between fine and coarse divisions of scintillator (0 or 1 for type)
+    // HGCScintillatorDetId defines two types of coarse divisions (1 or 2, and 0 still meaning fine divisions)
+    // Correct for this here
+    if (tc_type == 2) {
+      tc_type = 1;
+    }
+
     module_id =
         HGCalTriggerModuleDetId(HGCalTriggerSubdetector::HGCalHScTrigger, zside, tc_type, layer, sector, ieta, iphi);
   }

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -964,18 +964,29 @@ void HGCalTriggerGeometryV9Imp3::etaphiMappingFromSector0(int& ieta, int& iphi, 
 
 HGCalGeomRotation::WaferCentring HGCalTriggerGeometryV9Imp3::getWaferCentring(unsigned layer, int subdet) const {
   if (subdet == HGCalTriggerSubdetector::HGCalEETrigger) {  // CE-E
-    return HGCalGeomRotation::WaferCentring::WaferCentred;
+    return HGCalGeomRotation::WaferCentring::WaferCentred;  // All layers are wafer centred
   } else if (subdet == HGCalTriggerSubdetector::HGCalHSiTrigger) {
+    auto topologyLayerType = hsiTopology().dddConstants().layerType(layer);
+
     if ((layer % 2) == 1) {  // CE-H Odd
-      return HGCalGeomRotation::WaferCentring::CornerCentredY;
+      // Check topology for wafer centred layers, otherwise CornerCentredY
+      if (topologyLayerType == HGCalTypes::WaferCenter || topologyLayerType == HGCalTypes::WaferCenterR ||
+          topologyLayerType == HGCalTypes::WaferCenterB)
+        return HGCalGeomRotation::WaferCentring::WaferCentred;
+      else
+        return HGCalGeomRotation::WaferCentring::CornerCentredY;
     } else {  // CE-H Even
-      return HGCalGeomRotation::WaferCentring::CornerCentredMercedes;
+      // Check topology for wafer centred layers, otherwise CornerCentredMercedes
+      if (topologyLayerType == HGCalTypes::WaferCenter || topologyLayerType == HGCalTypes::WaferCenterR ||
+          topologyLayerType == HGCalTypes::WaferCenterB)
+        return HGCalGeomRotation::WaferCentring::WaferCentred;
+      else
+        return HGCalGeomRotation::WaferCentring::CornerCentredMercedes;
     }
   } else if (subdet == HGCalTriggerSubdetector::HFNoseTrigger) {  //HFNose
     return HGCalGeomRotation::WaferCentring::WaferCentred;
   } else {
-    edm::LogError("HGCalTriggerGeometryV9Imp3")
-        << "HGCalTriggerGeometryV9Imp3: trigger sub-detector expected to be silicon";
+    edm::LogError("HGCalTriggerGeometryV9") << "HGCalTriggerGeometryV9: trigger sub-detector expected to be silicon";
     return HGCalGeomRotation::WaferCentring::WaferCentred;
   }
 }

--- a/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
+++ b/L1Trigger/L1THGCal/plugins/geometries/HGCalTriggerGeometryV9Imp3.cc
@@ -269,7 +269,6 @@ unsigned HGCalTriggerGeometryV9Imp3::getModuleFromTriggerCell(const unsigned tri
     int ieta = 0;
     int iphi = 0;
     getScintillatoriEtaiPhi(ieta, iphi, tc_eta, tc_phi, layer);
-
     module_id =
         HGCalTriggerModuleDetId(HGCalTriggerSubdetector::HGCalHScTrigger, zside, tc_type, layer, sector, ieta, iphi);
   }

--- a/L1Trigger/L1THGCal/python/customTriggerGeometry.py
+++ b/L1Trigger/L1THGCal/python/customTriggerGeometry.py
@@ -11,6 +11,12 @@ def custom_geometry_V11_Imp3(process, stage1links=120):
         raise RuntimeError('{} Stage 1 input links is not supported. Supported options are 72 or 120 links'.format(stage1links))
     return process
 
+def custom_geometry_V16_Imp1(process):
+    process.l1tHGCalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV16Imp1')
+    process.l1tHGCalTriggerGeometryESProducer.TriggerGeometry.ScintillatorTriggerCellSize = cms.uint32(2)
+    process.l1tHGCalTriggerGeometryESProducer.TriggerGeometry.JsonMappingFile = cms.FileInPath("L1Trigger/L1THGCal/data/hgcal_trigger_link_mapping_120links_v1.json")
+    return process
+
 def custom_geometry_V11_Imp2(process, links='signaldriven'):
     process.l1tHGCalTriggerGeometryESProducer.TriggerGeometry.TriggerGeometryName = cms.string('HGCalTriggerGeometryV9Imp2')
     if links=='signaldriven':

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
@@ -24,7 +24,7 @@ from Configuration.Eras.Modifier_phase2_hgcalV16_cff import phase2_hgcalV16
 from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V10, custom_geometry_V11_Imp3, custom_geometry_V16_Imp1
 from L1Trigger.L1THGCal.customCalibration import  custom_cluster_calibration_global
 modifyHgcalTriggerPrimitivesWithV10Geometry_ = (phase2_hgcalV10 & ~phase2_hgcalV11).makeProcessModifier(custom_geometry_V10)
-modifyHgcalTriggerPrimitivesWithV11Geometry_ = phase2_hgcalV11.makeProcessModifier(custom_geometry_V11_Imp3)
+modifyHgcalTriggerPrimitivesWithV11Geometry_ = (phase2_hgcalV11 & ~phase2_hgcalV16).makeProcessModifier(custom_geometry_V11_Imp3)
 modifyHgcalTriggerPrimitivesWithV16Geometry_ = phase2_hgcalV16.makeProcessModifier(custom_geometry_V16_Imp1)
 
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim

--- a/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
+++ b/L1Trigger/L1THGCal/python/hgcalTriggerPrimitives_cff.py
@@ -20,10 +20,12 @@ phase2_hfnose.toReplaceWith(
 
 from Configuration.Eras.Modifier_phase2_hgcalV10_cff import phase2_hgcalV10
 from Configuration.Eras.Modifier_phase2_hgcalV11_cff import phase2_hgcalV11
-from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V10, custom_geometry_V11_Imp3
+from Configuration.Eras.Modifier_phase2_hgcalV16_cff import phase2_hgcalV16
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V10, custom_geometry_V11_Imp3, custom_geometry_V16_Imp1
 from L1Trigger.L1THGCal.customCalibration import  custom_cluster_calibration_global
 modifyHgcalTriggerPrimitivesWithV10Geometry_ = (phase2_hgcalV10 & ~phase2_hgcalV11).makeProcessModifier(custom_geometry_V10)
 modifyHgcalTriggerPrimitivesWithV11Geometry_ = phase2_hgcalV11.makeProcessModifier(custom_geometry_V11_Imp3)
+modifyHgcalTriggerPrimitivesWithV16Geometry_ = phase2_hgcalV16.makeProcessModifier(custom_geometry_V16_Imp1)
 
 from Configuration.ProcessModifiers.convertHGCalDigisSim_cff import convertHGCalDigisSim
 # can't declare a producer version of simHGCalUnsuppressedDigis in the normal flow of things,

--- a/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV16_cfg.py
+++ b/L1Trigger/L1THGCal/test/testHGCalL1TGeometryV16_cfg.py
@@ -60,8 +60,8 @@ process.endjob_step = cms.EndPath(process.endOfProcess)
 
 process.load('L1Trigger.L1THGCal.hgcalTriggerPrimitives_cff')
 # Eventually modify default geometry parameters
-from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp3
-process = custom_geometry_V11_Imp3(process)
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V16_Imp1
+process = custom_geometry_V16_Imp1(process)
 
 tester_cells = cms.PSet(
     TesterName = cms.string('HGCalTriggerGeoTesterCells')

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_newProcessors_V16_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_newProcessors_V16_cfg.py
@@ -67,8 +67,8 @@ process = custom_tower_standalone(process)
 process.hgcl1tpg_step = cms.Path(process.L1THGCalTriggerPrimitives)
 
 # Change to custom geometry
-from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp3
-process = custom_geometry_V11_Imp3(process)
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V16_Imp1
+process = custom_geometry_V16_Imp1(process)
 
 # load ntuplizer
 process.load('L1Trigger.L1THGCalUtilities.hgcalTriggerNtuples_cff')

--- a/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_stage1Firmware_V16_cfg.py
+++ b/L1Trigger/L1THGCalUtilities/test/testHGCalL1T_stage1Firmware_V16_cfg.py
@@ -64,8 +64,8 @@ from L1Trigger.L1THGCal.customLayer1 import custom_layer1_latestfw
 process = custom_layer1_latestfw(process)
 
 # Switch to latest trigger geometry containing information on links mapping
-from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V11_Imp3
-process = custom_geometry_V11_Imp3(process)
+from L1Trigger.L1THGCal.customTriggerGeometry import custom_geometry_V16_Imp1
+process = custom_geometry_V16_Imp1(process)
 
 process.hgcl1tpg_step = cms.Path(process.L1THGCalTriggerPrimitives)
 


### PR DESCRIPTION
#### PR description:

This PR fixes two inconsistencies with the V16 trigger geometry:
- The wafer centring of the CE-H were assumed to all be corner centred, but some are not wafer centred.  These cases are checked against the information from the topology class.
- HGCalTriggerModuleDetId only distinguishes between fine and coarse scintillator modules, however HGCScintillatorDetId also distinguishes between type "c" and "m" of coarse modules.  For now, I removed this distinction.

#### PR validation:

Checked the number of errorbits reported by the `HGCalTriggerGeoTesterBackendStage1` tester has reduced.  There are still inconsistencies, but fewer than before.

